### PR TITLE
Add macro for dag and ddag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /local
 
 # node

--- a/src/math.js
+++ b/src/math.js
@@ -47,8 +47,9 @@ exports.renderMath = (htmlString, callback) => {
         ket: ["|{#1}\\rangle", 1],
         braket: ["\\langle{#1}\\rangle}", 1],
         ketbra: ["\\ket{#1}\\bra{#2}", 2],
-
         hdots: ["\\dots", 0],
+        dag: ["\\dagger", 0],
+        ddag: ["\\ddagger", 0],
       },
       Augment: {
         Definitions: {macros: {


### PR DESCRIPTION
In https://www.arxiv-vanity.com/papers/1705.10119/, 
the \dag and \ddag are not shown properly.

![snap](https://user-images.githubusercontent.com/29617239/31981394-f5dde8b8-b98d-11e7-9e9e-392dafbe2c16.png)

So I added these two macros to mathjax.