### PR TITLE
Don't mount node_modules as volume in development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ ENV LATEXML_COMMIT=d33e9a32d18407fa9488857d4100b532b1548884
 RUN curl -L https://github.com/brucemiller/LaTeXML/tarball/$LATEXML_COMMIT | tar --strip-components 1 -zxf -
 RUN perl Makefile.PL; make; make install
 
-RUN mkdir -p /app
-RUN chown engrafo:engrafo /app
+RUN mkdir -p /app /node_modules
+RUN chown engrafo:engrafo /app /node_modules
 WORKDIR /app
 
 # server
@@ -69,8 +69,12 @@ RUN pip install -r server/requirements.txt
 USER engrafo
 
 # Node
-COPY package.json yarn.lock /app/
-RUN yarn
+COPY package.json yarn.lock /
+# HACK: Install node_modules one directory up so they are not overwritten
+# in development. The other workaround is using a volume for node_modules,
+# but is really slow and hard to update.
+RUN cd /; yarn install --pure-lockfile
+ENV PATH /node_modules/.bin:$PATH
 
 ENV PYTHONUNBUFFERED=1
 ENV PATH="/app/bin:${PATH}"

--- a/script/engrafo
+++ b/script/engrafo
@@ -3,7 +3,6 @@ ENGRAFO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 exec docker run \
     -v "$(pwd)":/workdir -w /workdir \
-    -v "/app/node_modules" \
     -v "$ENGRAFO_DIR:/app" \
     --rm \
     -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_REGION_NAME \

--- a/script/run
+++ b/script/run
@@ -2,7 +2,6 @@
 ENGRAFO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 exec docker run \
-    -v "/app/node_modules" \
     -v "$ENGRAFO_DIR:/app" \
     -w /app \
     --rm \

--- a/script/server
+++ b/script/server
@@ -2,7 +2,6 @@
 ENGRAFO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 exec docker run \
-    -v "/app/node_modules" \
     -v "$ENGRAFO_DIR:/app" \
     -w /app \
     -p 8010:8010 \

--- a/script/test
+++ b/script/test
@@ -2,10 +2,9 @@
 ENGRAFO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 exec docker run \
-    -v "/app/node_modules" \
     -v "$ENGRAFO_DIR:/app" \
     --rm \
     -it \
     --cap-add=SYS_ADMIN \
     engrafo \
-    node_modules/.bin/jest --silent "$@"
+    jest --silent "$@"

--- a/src/postprocessor/styles.js
+++ b/src/postprocessor/styles.js
@@ -162,7 +162,7 @@ dt-article .engrafo-metadata {
 `;
 
 module.exports = function(dom) {
-  var distillPath = path.join(__dirname, "../../node_modules/distill-template/");
+  var distillPath = "/node_modules/distill-template/";
   var layout = fs.readFileSync(path.join(distillPath, "components/styles-layout.css"));
   var article = fs.readFileSync(path.join(distillPath, "components/styles-article.css"));
   var code = fs.readFileSync(path.join(distillPath, "components/styles-code.css"));


### PR DESCRIPTION
It takes ~5s to mount, which is infuriating when developing.
This hugely speeds up all the development commands. Tests seem to
run a lot faster than 5s for some reason (44s instead of >1m).

The only downside of this approach is that node_modules in the
local dir is going to fuck things up. We should make a check
for that.