### PR TITLE
Store document snapshots as strings

### DIFF
--- a/tests/__snapshots__/integration.test.js.snap
+++ b/tests/__snapshots__/integration.test.js.snap
@@ -1,7508 +1,706 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`aa.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document ltx_authors_1line"
-    >
-      
-
-      <h1
-        class="ltx_title ltx_title_document"
-      >
-        Test for Astronomy & Astrophysics package
-      </h1>
-      
-
-      <div
-        class="ltx_subtitle"
-      >
-        This is a subtitle
-
-      </div>
-      
-
-      <div
-        class="ltx_authors"
-      >
-        
-
-        <span
-          class="ltx_creator ltx_role_author"
-        >
-          
-
-          <span
-            class="ltx_personname"
-          >
-            Carl Capybara
-
-          </span>
-        </span>
-        
-
-      </div>
-      
-
-
-      <div
-        class="ltx_keywords"
-      >
-        
-
-        <h6
-          class="ltx_title ltx_title_keywords"
-        >
-          Key Words.:
-        </h6>
-        galaxies: bulges – galaxies: elliptical and lenticular, cD – galaxies: evolution – galaxies: formation – galaxies: interactions – galaxies: structure
-
-      </div>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document ltx_authors_1line\\">
+<h1 class=\\"ltx_title ltx_title_document\\">Test for Astronomy &amp; Astrophysics package</h1>
+<div class=\\"ltx_subtitle\\">This is a subtitle
 </div>
+<div class=\\"ltx_authors\\">
+<span class=\\"ltx_creator ltx_role_author\\">
+<span class=\\"ltx_personname\\">Carl Capybara
+</span></span>
+</div>
+
+<div class=\\"ltx_keywords\\">
+<h6 class=\\"ltx_title ltx_title_keywords\\">Key Words.:</h6>galaxies: bulges – galaxies: elliptical and lenticular, cD – galaxies: evolution – galaxies: formation – galaxies: interactions – galaxies: structure
+</div>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`acronym.sty.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Intro</h2>
 
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Intro
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            In the early nineties, 
-            <a
-              href="#id2"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id2"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  GSM
-                </span>
-              </abbr>
-            </a>
-             was deployed in many European
-countries.  
-            <a
-              href="#id2"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id2"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Global System for Mobile communication
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id2"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id2"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  GSM
-                </span>
-              </abbr>
-            </a>
-            ) offered for the first time international
-roaming for mobile subscribers. The 
-            <a
-              href="#id2"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id2"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  GSM
-                </span>
-              </abbr>
-            </a>
-            ’s use of  
-            <a
-              href="#id6"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id6"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Time Division Multiple Access
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id6"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id6"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  TDMA
-                </span>
-              </abbr>
-            </a>
-            ) as
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">In the early nineties, <a href=\\"#id2\\"><abbr href=\\"#id2\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">GSM</span></abbr></a> was deployed in many European
+countries.  <a href=\\"#id2\\"><span href=\\"#id2\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Global System for Mobile communication</span></span></a> (<a href=\\"#id2\\"><abbr href=\\"#id2\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">GSM</span></abbr></a>) offered for the first time international
+roaming for mobile subscribers. The <a href=\\"#id2\\"><abbr href=\\"#id2\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">GSM</span></abbr></a>’s use of  <a href=\\"#id6\\"><span href=\\"#id6\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Time Division Multiple Access</span></span></a> (<a href=\\"#id6\\"><abbr href=\\"#id6\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">TDMA</span></abbr></a>) as
 its communication standard was debated at length. And every now
-and then there are big discussion whether  
-            <a
-              href="#id1"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id1"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Code Division Multiple Access
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id1"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id1"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  CDMA
-                </span>
-              </abbr>
-            </a>
-            ) should have
-been chosen over 
-            <a
-              href="#id6"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id6"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  TDMA
-                </span>
-              </abbr>
-            </a>
-            .
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S2"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            2 
-          </span>
-          Furthermore
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S2.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            The reader could have forgotten all the nice acronyms, so we repeat the
-meaning again.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S2.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            If you want to know more about  
-            <a
-              href="#id2"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id2"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Global System for Mobile communication
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id2"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id2"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  GSM
-                </span>
-              </abbr>
-            </a>
-            ),  
-            <a
-              href="#id6"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id6"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Time Division Multiple Access
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id6"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id6"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  TDMA
-                </span>
-              </abbr>
-            </a>
-            ),  
-            <a
-              href="#id1"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id1"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Code Division Multiple Access
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id1"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id1"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  CDMA
-                </span>
-              </abbr>
-            </a>
-            )
-and other acronyms, just read a book about mobile communication. Just
-to mention it: There is another  
-            <a
-              href="#id7"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id7"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Used Acronym
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id7"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id7"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  UA
-                </span>
-              </abbr>
-            </a>
-            ), just for testing purposes!
-          </p>
-          
-
-        </div>
-        
-
-        <figure
-          class="ltx_figure"
-          id="S2.F1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Figure
-          </p>
-          
-
-          <figcaption
-            class="ltx_caption"
-          >
-            <span
-              class="ltx_tag ltx_tag_figure"
-            >
-              Figure 1: 
-            </span>
-            A float also admits references like 
-            <a
-              href="#id2"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id2"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  GSM
-                </span>
-              </abbr>
-            </a>
-             or  
-            <a
-              href="#id1"
-            >
-              <span
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id1"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_long"
-                >
-                  Code Division Multiple Access
-                </span>
-              </span>
-            </a>
-             (
-            <a
-              href="#id1"
-            >
-              <abbr
-                class="ltx_glossaryref ltx_role_acronym"
-                href="#id1"
-                title=""
-              >
-                <span
-                  class="ltx_text ltx_glossary_short"
-                >
-                  CDMA
-                </span>
-              </abbr>
-            </a>
-            ).
-          </figcaption>
-          
-
-        </figure>
-        
-
-        <section
-          class="ltx_subsection"
-          id="S2.SS1"
-        >
-          
-
-          <h3
-            class="ltx_title ltx_title_subsection"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_subsection"
-            >
-              2.1 
-            </span>
-            Some chemistry and physics
-          </h3>
-          
-
-
-          <div
-            class="ltx_para"
-            id="S2.SS1.p1"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              <a
-                href="#id4"
-              >
-                <span
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id4"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_long"
-                  >
-                    Nicotinamide Adenine Dinucleotide
-                  </span>
-                </span>
-              </a>
-               (
-              <a
-                href="#id4"
-              >
-                <abbr
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id4"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_short"
-                  >
-                    NAD
-                    <sup
-                      class="ltx_sup"
-                    >
-                      +
-                    </sup>
-                  </span>
-                </abbr>
-              </a>
-              ) is a major electron acceptor in the oxidation
-of fuel molecules. The reactive part of 
-              <a
-                href="#id4"
-              >
-                <abbr
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id4"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_short"
-                  >
-                    NAD
-                    <sup
-                      class="ltx_sup"
-                    >
-                      +
-                    </sup>
-                  </span>
-                </abbr>
-              </a>
-               is its nictinamide
-ring, a pyridine derivate.
-            </p>
-            
-
-          </div>
-          
-
-          <div
-            class="ltx_para"
-            id="S2.SS1.p2"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              One mol consists of 
-              <a
-                href="#id3"
-              >
-                <abbr
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id3"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_short"
-                  >
-                    <span
-                      class="ltx_Math"
-                    >
-                      <span
-                        class="mjpage"
-                      >
-                        <span
-                          class="mjx-chtml"
-                        >
-                          <span
-                            aria-label="N_{\\\\mathrm{A}}"
-                            class="mjx-math"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-msubsup"
-                              >
-                                <span
-                                  class="mjx-base"
-                                  style="margin-right: -0.085em;"
-                                >
-                                  <span
-                                    class="mjx-mi"
-                                  >
-                                    <span
-                                      class="mjx-char MJXc-TeX-math-I"
-                                      style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.085em;"
-                                    >
-                                      N
-                                    </span>
-                                  </span>
-                                </span>
-                                <span
-                                  class="mjx-sub"
-                                  style="font-size: 70.7%; vertical-align: -0.241em; padding-right: 0.071em;"
-                                >
-                                  <span
-                                    class="mjx-texatom"
-                                    style=""
-                                  >
-                                    <span
-                                      class="mjx-mrow"
-                                    >
-                                      <span
-                                        class="mjx-texatom"
-                                      >
-                                        <span
-                                          class="mjx-mrow"
-                                        >
-                                          <span
-                                            class="mjx-mi"
-                                          >
-                                            <span
-                                              class="mjx-char MJXc-TeX-main-R"
-                                              style="padding-top: 0.446em; padding-bottom: 0.372em;"
-                                            >
-                                              A
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </abbr>
-              </a>
-               atoms or molecules. There is a relation
-between the constant of Boltzmann and the 
-              <a
-                href="#id3"
-              >
-                <span
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id3"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_long"
-                  >
-                    Number of Avogadro
-                  </span>
-                </span>
-              </a>
-              :
-            </p>
-            
-
-            <table
-              class="ltx_equation ltx_eqn_table"
-              id="S2.E1"
-            >
-              
-
-
-              <tbody>
-                <tr
-                  class="ltx_equation ltx_eqn_row ltx_align_baseline"
-                >
-                  
-
-                  <td
-                    class="ltx_eqn_cell ltx_eqn_center_padleft"
-                  />
-                  
-
-                  <td
-                    class="ltx_eqn_cell ltx_align_center"
-                  >
-                    <span
-                      class="ltx_DisplayMath"
-                      id="S2.E1.m1"
-                    >
-                      <span
-                        class="mjpage mjpage__block"
-                      >
-                        <span
-                          class="mjx-chtml MJXc-display"
-                          style="text-align: left;"
-                        >
-                          <span
-                            aria-label=" k=R/\\\\AC@acs{NA} "
-                            class="mjx-math"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                >
-                                  k
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mo MJXc-space3"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.077em; padding-bottom: 0.298em;"
-                                >
-                                  =
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi MJXc-space3"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                >
-                                  R
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-texatom"
-                              >
-                                <span
-                                  class="mjx-mrow"
-                                >
-                                  <span
-                                    class="mjx-mo"
-                                  >
-                                    <span
-                                      class="mjx-char MJXc-TeX-main-R"
-                                      style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                                    >
-                                      /
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mtext"
-                                style="color: red;"
-                              >
-                                <span
-                                  class="mjx-char"
-                                  style="padding-top: 0.519em; padding-bottom: 0.225em;"
-                                >
-                                  <span
-                                    class="mjx-charbox MJXc-font-inherit"
-                                    style="font-size: 100%; padding-bottom: 0.3em; width: 1.5em;"
-                                  >
-                                    \\AC
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-texatom"
-                              >
-                                <span
-                                  class="mjx-mrow"
-                                >
-                                  <span
-                                    class="mjx-mo"
-                                  >
-                                    <span
-                                      class="mjx-char MJXc-TeX-main-R"
-                                      style="padding-top: 0.446em; padding-bottom: 0.372em;"
-                                    >
-                                      @
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                >
-                                  a
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                >
-                                  c
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                >
-                                  s
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-texatom"
-                              >
-                                <span
-                                  class="mjx-mrow"
-                                >
-                                  <span
-                                    class="mjx-mi"
-                                  >
-                                    <span
-                                      class="mjx-char MJXc-TeX-math-I"
-                                      style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.085em;"
-                                    >
-                                      N
-                                    </span>
-                                  </span>
-                                  <span
-                                    class="mjx-mi"
-                                  >
-                                    <span
-                                      class="mjx-char MJXc-TeX-math-I"
-                                      style="padding-top: 0.519em; padding-bottom: 0.298em;"
-                                    >
-                                      A
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </td>
-                  
-
-                  <td
-                    class="ltx_eqn_cell ltx_eqn_center_padright"
-                  />
-                  
-
-                  <td
-                    class="ltx_eqn_cell ltx_eqn_eqno ltx_align_middle ltx_align_right"
-                    rowspan="1"
-                  >
-                    <span
-                      class="ltx_tag ltx_tag_equation ltx_align_right"
-                    >
-                      (1)
-                    </span>
-                  </td>
-                  
-
-                </tr>
-                
-
-              </tbody>
-            </table>
-            
-
-          </div>
-          
-
-          <div
-            class="ltx_para"
-            id="S2.SS1.p3"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              <a
-                href="#id8"
-              >
-                <span
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id8"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_long"
-                  >
-                    Liquid Oxygen
-                  </span>
-                </span>
-              </a>
-              /
-              <a
-                href="#id9"
-              >
-                <span
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id9"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_long"
-                  >
-                    Liquid Hydrogen
-                  </span>
-                </span>
-              </a>
-               (
-              <a
-                href="#id8"
-              >
-                <abbr
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id8"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_short"
-                  >
-                    <span
-                      class="ltx_Math"
-                    >
-                      <span
-                        class="mjpage"
-                      >
-                        <span
-                          class="mjx-chtml"
-                        >
-                          <span
-                            aria-label="LOX"
-                            class="mjx-math"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                >
-                                  L
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.519em; padding-bottom: 0.298em;"
-                                >
-                                  O
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;"
-                                >
-                                  X
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </abbr>
-              </a>
-              /
-              <a
-                href="#id9"
-              >
-                <abbr
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id9"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_short"
-                  >
-                    <span
-                      class="ltx_Math"
-                    >
-                      <span
-                        class="mjpage"
-                      >
-                        <span
-                          class="mjx-chtml"
-                        >
-                          <span
-                            aria-label="LH_{2}"
-                            class="mjx-math"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                >
-                                  L
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-msubsup"
-                              >
-                                <span
-                                  class="mjx-base"
-                                  style="margin-right: -0.057em;"
-                                >
-                                  <span
-                                    class="mjx-mi"
-                                  >
-                                    <span
-                                      class="mjx-char MJXc-TeX-math-I"
-                                      style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.057em;"
-                                    >
-                                      H
-                                    </span>
-                                  </span>
-                                </span>
-                                <span
-                                  class="mjx-sub"
-                                  style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"
-                                >
-                                  <span
-                                    class="mjx-texatom"
-                                    style=""
-                                  >
-                                    <span
-                                      class="mjx-mrow"
-                                    >
-                                      <span
-                                        class="mjx-mn"
-                                      >
-                                        <span
-                                          class="mjx-char MJXc-TeX-main-R"
-                                          style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                        >
-                                          2
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </abbr>
-              </a>
-              )
-            </p>
-            
-
-          </div>
-          
-
-        </section>
-        
-
-        <section
-          class="ltx_subsection"
-          id="S2.SS2"
-        >
-          
-
-          <h3
-            class="ltx_title ltx_title_subsection"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_subsection"
-            >
-              2.2 
-            </span>
-            Some testing fundamentals
-          </h3>
-          
-
-
-          <div
-            class="ltx_para"
-            id="S2.SS2.p1"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              When testing 
-              <a
-                href="#id10"
-              >
-                <span
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id10"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_long-plural"
-                  >
-                    Integrated Circuits
-                  </span>
-                </span>
-              </a>
-              , one typically wants to identify functional
-blocks to be tested separately. The latter are commonly indicated as
-
-              <a
-                href="#id11"
-              >
-                <span
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id11"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_long-plural"
-                  >
-                    Blocks Under Test
-                  </span>
-                </span>
-              </a>
-              . To test a 
-              <a
-                href="#id11"
-              >
-                <abbr
-                  class="ltx_glossaryref ltx_role_acronym"
-                  href="#id11"
-                  title=""
-                >
-                  <span
-                    class="ltx_text ltx_glossary_short"
-                  >
-                    BUT
-                  </span>
-                </abbr>
-              </a>
-               requires defining a testing strategy…
-            </p>
-            
-
-          </div>
-          
-
-        </section>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S3"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            3 
-          </span>
-          Acronyms
-        </h2>
-        
-
-
-      </section>
-      
-
-      <section
-        class="ltx_glossary ltx_acronym ltx_role_acronym"
-      >
-        
-
-        <dl
-          class="ltx_glossarylist"
-        >
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id1"
-          >
-            CDMA
-          </dt>
-          
-
-          <dd>
-            Code Division Multiple Access
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id2"
-          >
-            GSM
-          </dt>
-          
-
-          <dd>
-            Global System for Mobile communication
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id3"
-          >
-            <span
-              class="ltx_Math"
-              id="m1"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="N_{\\\\mathrm{A}}"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-msubsup"
-                      >
-                        <span
-                          class="mjx-base"
-                          style="margin-right: -0.085em;"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.085em;"
-                            >
-                              N
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sub"
-                          style="font-size: 70.7%; vertical-align: -0.241em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-texatom"
-                              >
-                                <span
-                                  class="mjx-mrow"
-                                >
-                                  <span
-                                    class="mjx-mi"
-                                  >
-                                    <span
-                                      class="mjx-char MJXc-TeX-main-R"
-                                      style="padding-top: 0.446em; padding-bottom: 0.372em;"
-                                    >
-                                      A
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-          </dt>
-          
-
-          <dd>
-            Number of Avogadro (see §
-            <a
-              class="ltx_ref"
-              href="#S2.SS1"
-              title="2.1 Some chemistry and physics ‣ 2 Furthermore"
-            >
-              <span
-                class="ltx_text ltx_ref_tag"
-              >
-                2.1
-              </span>
-            </a>
-            )
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id4"
-          >
-            NAD
-            <sup
-              class="ltx_sup"
-            >
-              +
-            </sup>
-            
-
-          </dt>
-          
-
-          <dd>
-            Nicotinamide Adenine Dinucleotide
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id5"
-          >
-            NUA
-          </dt>
-          
-
-          <dd>
-            Not Used Acronym
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id6"
-          >
-            TDMA
-          </dt>
-          
-
-          <dd>
-            Time Division Multiple Access
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id7"
-          >
-            UA
-          </dt>
-          
-
-          <dd>
-            Used Acronym
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id8"
-          >
-            <span
-              class="ltx_Math"
-              id="m3"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="LOX"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                        >
-                          L
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.519em; padding-bottom: 0.298em;"
-                        >
-                          O
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;"
-                        >
-                          X
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-          </dt>
-          
-
-          <dd>
-            Liquid Oxygen
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id9"
-          >
-            <span
-              class="ltx_Math"
-              id="m5"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="LH_{2}"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                        >
-                          L
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup"
-                      >
-                        <span
-                          class="mjx-base"
-                          style="margin-right: -0.057em;"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.057em;"
-                            >
-                              H
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sub"
-                          style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mn"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                >
-                                  2
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-          </dt>
-          
-
-          <dd>
-            Liquid Hydrogen
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id10"
-          >
-            IC
-          </dt>
-          
-
-          <dd>
-            Integrated Circuit
-          </dd>
-          
-
-          <dt
-            class="ltx_glossaryentry ltx_role_acronym"
-            id="id11"
-          >
-            BUT
-          </dt>
-          
-
-          <dd>
-            Block Under Test
-          </dd>
-          
-
-        </dl>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+and then there are big discussion whether  <a href=\\"#id1\\"><span href=\\"#id1\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Code Division Multiple Access</span></span></a> (<a href=\\"#id1\\"><abbr href=\\"#id1\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">CDMA</span></abbr></a>) should have
+been chosen over <a href=\\"#id6\\"><abbr href=\\"#id6\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">TDMA</span></abbr></a>.</p>
 </div>
+</section>
+<section id=\\"S2\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">2 </span>Furthermore</h2>
+
+<div id=\\"S2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">The reader could have forgotten all the nice acronyms, so we repeat the
+meaning again.</p>
+</div>
+<div id=\\"S2.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">If you want to know more about  <a href=\\"#id2\\"><span href=\\"#id2\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Global System for Mobile communication</span></span></a> (<a href=\\"#id2\\"><abbr href=\\"#id2\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">GSM</span></abbr></a>),  <a href=\\"#id6\\"><span href=\\"#id6\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Time Division Multiple Access</span></span></a> (<a href=\\"#id6\\"><abbr href=\\"#id6\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">TDMA</span></abbr></a>),  <a href=\\"#id1\\"><span href=\\"#id1\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Code Division Multiple Access</span></span></a> (<a href=\\"#id1\\"><abbr href=\\"#id1\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">CDMA</span></abbr></a>)
+and other acronyms, just read a book about mobile communication. Just
+to mention it: There is another  <a href=\\"#id7\\"><span href=\\"#id7\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Used Acronym</span></span></a> (<a href=\\"#id7\\"><abbr href=\\"#id7\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">UA</span></abbr></a>), just for testing purposes!</p>
+</div>
+<figure id=\\"S2.F1\\" class=\\"ltx_figure\\">
+<p class=\\"ltx_p\\">Figure</p>
+<figcaption class=\\"ltx_caption\\"><span class=\\"ltx_tag ltx_tag_figure\\">Figure 1: </span>A float also admits references like <a href=\\"#id2\\"><abbr href=\\"#id2\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">GSM</span></abbr></a> or  <a href=\\"#id1\\"><span href=\\"#id1\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Code Division Multiple Access</span></span></a> (<a href=\\"#id1\\"><abbr href=\\"#id1\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">CDMA</span></abbr></a>).</figcaption>
+</figure>
+<section id=\\"S2.SS1\\" class=\\"ltx_subsection\\">
+<h3 class=\\"ltx_title ltx_title_subsection\\">
+<span class=\\"ltx_tag ltx_tag_subsection\\">2.1 </span>Some chemistry and physics</h3>
+
+<div id=\\"S2.SS1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\"><a href=\\"#id4\\"><span href=\\"#id4\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Nicotinamide Adenine Dinucleotide</span></span></a> (<a href=\\"#id4\\"><abbr href=\\"#id4\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">NAD<sup class=\\"ltx_sup\\">+</sup></span></abbr></a>) is a major electron acceptor in the oxidation
+of fuel molecules. The reactive part of <a href=\\"#id4\\"><abbr href=\\"#id4\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">NAD<sup class=\\"ltx_sup\\">+</sup></span></abbr></a> is its nictinamide
+ring, a pyridine derivate.</p>
+</div>
+<div id=\\"S2.SS1.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">One mol consists of <a href=\\"#id3\\"><abbr href=\\"#id3\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\"><span class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"N_{\\\\mathrm{A}}\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.085em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.085em;\\">N</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.241em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-texatom\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.372em;\\">A</span></span></span></span></span></span></span></span></span></span></span></span></span></span></abbr></a> atoms or molecules. There is a relation
+between the constant of Boltzmann and the <a href=\\"#id3\\"><span href=\\"#id3\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Number of Avogadro</span></span></a>:</p>
+<table id=\\"S2.E1\\" class=\\"ltx_equation ltx_eqn_table\\">
+
+<tbody><tr class=\\"ltx_equation ltx_eqn_row ltx_align_baseline\\">
+<td class=\\"ltx_eqn_cell ltx_eqn_center_padleft\\"></td>
+<td class=\\"ltx_eqn_cell ltx_align_center\\"><span id=\\"S2.E1.m1\\" class=\\"ltx_DisplayMath\\"><span class=\\"mjpage mjpage__block\\"><span class=\\"mjx-chtml MJXc-display\\" style=\\"text-align: left;\\"><span class=\\"mjx-math\\" aria-label=\\" k=R/\\\\AC@acs{NA} \\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">k</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.077em; padding-bottom: 0.298em;\\">=</span></span><span class=\\"mjx-mi MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">R</span></span><span class=\\"mjx-texatom\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">/</span></span></span></span><span class=\\"mjx-mtext\\" style=\\"color: red;\\"><span class=\\"mjx-char\\" style=\\"padding-top: 0.519em; padding-bottom: 0.225em;\\"><span class=\\"mjx-charbox MJXc-font-inherit\\" style=\\"font-size: 100%; padding-bottom: 0.3em; width: 1.5em;\\">\\\\AC</span></span></span><span class=\\"mjx-texatom\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.372em;\\">@</span></span></span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">a</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">c</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">s</span></span><span class=\\"mjx-texatom\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.085em;\\">N</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.519em; padding-bottom: 0.298em;\\">A</span></span></span></span></span></span></span></span></span></td>
+<td class=\\"ltx_eqn_cell ltx_eqn_center_padright\\"></td>
+<td rowspan=\\"1\\" class=\\"ltx_eqn_cell ltx_eqn_eqno ltx_align_middle ltx_align_right\\"><span class=\\"ltx_tag ltx_tag_equation ltx_align_right\\">(1)</span></td>
+</tr>
+</tbody></table>
+</div>
+<div id=\\"S2.SS1.p3\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\"><a href=\\"#id8\\"><span href=\\"#id8\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Liquid Oxygen</span></span></a>/<a href=\\"#id9\\"><span href=\\"#id9\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long\\">Liquid Hydrogen</span></span></a> (<a href=\\"#id8\\"><abbr href=\\"#id8\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\"><span class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"LOX\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">L</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.519em; padding-bottom: 0.298em;\\">O</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;\\">X</span></span></span></span></span></span></span></span></abbr></a>/<a href=\\"#id9\\"><abbr href=\\"#id9\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\"><span class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"LH_{2}\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">L</span></span><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.057em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.057em;\\">H</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span></span></span></span></span></span></span></span></span></span></span></abbr></a>)</p>
+</div>
+</section>
+<section id=\\"S2.SS2\\" class=\\"ltx_subsection\\">
+<h3 class=\\"ltx_title ltx_title_subsection\\">
+<span class=\\"ltx_tag ltx_tag_subsection\\">2.2 </span>Some testing fundamentals</h3>
+
+<div id=\\"S2.SS2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">When testing <a href=\\"#id10\\"><span href=\\"#id10\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long-plural\\">Integrated Circuits</span></span></a>, one typically wants to identify functional
+blocks to be tested separately. The latter are commonly indicated as
+<a href=\\"#id11\\"><span href=\\"#id11\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_long-plural\\">Blocks Under Test</span></span></a>. To test a <a href=\\"#id11\\"><abbr href=\\"#id11\\" title=\\"\\" class=\\"ltx_glossaryref ltx_role_acronym\\"><span class=\\"ltx_text ltx_glossary_short\\">BUT</span></abbr></a> requires defining a testing strategy…</p>
+</div>
+</section>
+</section>
+<section id=\\"S3\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">3 </span>Acronyms</h2>
+
+</section>
+<section class=\\"ltx_glossary ltx_acronym ltx_role_acronym\\">
+<dl class=\\"ltx_glossarylist\\">
+<dt id=\\"id1\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">CDMA</dt>
+<dd>Code Division Multiple Access</dd>
+<dt id=\\"id2\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">GSM</dt>
+<dd>Global System for Mobile communication</dd>
+<dt id=\\"id3\\" class=\\"ltx_glossaryentry ltx_role_acronym\\"><span id=\\"m1\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"N_{\\\\mathrm{A}}\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.085em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.085em;\\">N</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.241em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-texatom\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.372em;\\">A</span></span></span></span></span></span></span></span></span></span></span></span></span></dt>
+<dd>Number of Avogadro (see §<a href=\\"#S2.SS1\\" title=\\"2.1 Some chemistry and physics ‣ 2 Furthermore\\" class=\\"ltx_ref\\"><span class=\\"ltx_text ltx_ref_tag\\">2.1</span></a>)</dd>
+<dt id=\\"id4\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">NAD<sup class=\\"ltx_sup\\">+</sup>
+</dt>
+<dd>Nicotinamide Adenine Dinucleotide</dd>
+<dt id=\\"id5\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">NUA</dt>
+<dd>Not Used Acronym</dd>
+<dt id=\\"id6\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">TDMA</dt>
+<dd>Time Division Multiple Access</dd>
+<dt id=\\"id7\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">UA</dt>
+<dd>Used Acronym</dd>
+<dt id=\\"id8\\" class=\\"ltx_glossaryentry ltx_role_acronym\\"><span id=\\"m3\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"LOX\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">L</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.519em; padding-bottom: 0.298em;\\">O</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;\\">X</span></span></span></span></span></span></span></dt>
+<dd>Liquid Oxygen</dd>
+<dt id=\\"id9\\" class=\\"ltx_glossaryentry ltx_role_acronym\\"><span id=\\"m5\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"LH_{2}\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">L</span></span><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.057em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.057em;\\">H</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span></span></span></span></span></span></span></span></span></span></dt>
+<dd>Liquid Hydrogen</dd>
+<dt id=\\"id10\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">IC</dt>
+<dd>Integrated Circuit</dd>
+<dt id=\\"id11\\" class=\\"ltx_glossaryentry ltx_role_acronym\\">BUT</dt>
+<dd>Block Under Test</dd>
+</dl>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`algorithm.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Algorithms
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Given an index configuration, which specifies the number of stages and the number of models per stage as an array of sizes, the end-to-end training for hybrid indexes is done as shown in Algorithm 
-            <a
-              class="ltx_ref"
-              href="#algorithm1"
-              title="Algorithm 1 ‣ 1 Algorithms"
-            >
-              <span
-                class="ltx_text ltx_ref_tag"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  1
-                </span>
-              </span>
-            </a>
-          </p>
-          
-
-        </div>
-        
-
-        <figure
-          class="ltx_float"
-          id="algorithm1"
-        >
-          
-
-          <div
-            class="ltx_listing ltx_lst_numbers_left ltx_listing"
-          >
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                <span
-                  class="ltx_text ltx_font_bold"
-                >
-                  Input:
-                </span>
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                int threshold, int stages[], NN_complexity
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                <span
-                  class="ltx_text ltx_font_bold"
-                >
-                  Data:
-                </span>
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                record data[], Model index[][]
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                <span
-                  class="ltx_text ltx_font_bold"
-                >
-                  Result:
-                </span>
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                trained index 
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  1
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m1"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="M"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                          >
-                            M
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 = stages.size;
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  2
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 tmp_records[][];
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  3
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 tmp_records[1][1] = all_data;
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  4
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                for
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m2"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="i\\\\leftarrow 1"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            i
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                          >
-                            ←
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mn MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text ltx_font_italic"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                to
-              </span>
-              <span
-                class="ltx_text ltx_emph ltx_font_italic"
-                style="font-size:80%;"
-              >
-                 
-                <span
-                  class="ltx_Math"
-                  id="algorithm1.m3"
-                >
-                  <span
-                    class="mjpage"
-                  >
-                    <span
-                      class="mjx-chtml"
-                    >
-                      <span
-                        aria-label="M"
-                        class="mjx-math"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="mjx-mrow"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                            >
-                              M
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                do
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  5
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                for
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m4"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="j\\\\leftarrow 1"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                          >
-                            ←
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mn MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text ltx_font_italic"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                to
-              </span>
-              <span
-                class="ltx_text ltx_emph ltx_font_italic"
-                style="font-size:80%;"
-              >
-                 
-                <span
-                  class="ltx_Math"
-                  id="algorithm1.m5"
-                >
-                  <span
-                    class="mjpage"
-                  >
-                    <span
-                      class="mjx-chtml"
-                    >
-                      <span
-                        aria-label="stages[i]"
-                        class="mjx-math"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="mjx-mrow"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              s
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.372em; padding-bottom: 0.298em;"
-                            >
-                              t
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              a
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;"
-                            >
-                              g
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              e
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              s
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mo"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-main-R"
-                              style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                            >
-                              [
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                            >
-                              i
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mo"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-main-R"
-                              style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                            >
-                              ]
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                do
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  6
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 index[i][j] = new NN trained on tmp_records[
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m6"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="i"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            i
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ][
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m7"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="j"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ];
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline ltx_emph"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  7
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                if
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m8"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="i<M"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            i
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                          >
-                            &lt;
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                          >
-                            M
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                then
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  8
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                for
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m9"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="r\\\\in"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            r
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                          >
-                            ∈
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text ltx_emph ltx_font_italic"
-                style="font-size:80%;"
-              >
-                 tmp_records[
-                <span
-                  class="ltx_Math"
-                  id="algorithm1.m10"
-                >
-                  <span
-                    class="mjpage"
-                  >
-                    <span
-                      class="mjx-chtml"
-                    >
-                      <span
-                        aria-label="i"
-                        class="mjx-math"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="mjx-mrow"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                            >
-                              i
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-                ][
-                <span
-                  class="ltx_Math"
-                  id="algorithm1.m11"
-                >
-                  <span
-                    class="mjpage"
-                  >
-                    <span
-                      class="mjx-chtml"
-                    >
-                      <span
-                        aria-label="j"
-                        class="mjx-math"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="mjx-mrow"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                            >
-                              j
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-                ]
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                do
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  9
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m12"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="p"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.446em;"
-                          >
-                            p
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 = index[i][j]
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m13"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="(r.key)"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                          >
-                            (
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            r
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="margin-top: -0.144em; padding-bottom: 0.372em;"
-                          >
-                            .
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi MJXc-space1"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            k
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            e
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;"
-                          >
-                            y
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                          >
-                            )
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 / stages[
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m14"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="i+1"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            i
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space2"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                          >
-                            +
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mn MJXc-space2"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ];
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  10
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 tmp_records[
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m15"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="i+1"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            i
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space2"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                          >
-                            +
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mn MJXc-space2"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ][
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m16"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="p"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.446em;"
-                          >
-                            p
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ].add(
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m17"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="r"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            r
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                );
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  11
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  12
-                </span>
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                for
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m18"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="j\\\\leftarrow 1"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                          >
-                            ←
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mn MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text ltx_font_italic"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                to
-              </span>
-              <span
-                class="ltx_text ltx_emph ltx_font_italic"
-                style="font-size:80%;"
-              >
-                 
-                <span
-                  class="ltx_Math"
-                  id="algorithm1.m19"
-                >
-                  <span
-                    class="mjpage"
-                  >
-                    <span
-                      class="mjx-chtml"
-                    >
-                      <span
-                        aria-label="index[M].size"
-                        class="mjx-math"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="mjx-mrow"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                            >
-                              i
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              n
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                            >
-                              d
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              e
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              x
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mo"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-main-R"
-                              style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                            >
-                              [
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                            >
-                              M
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mo"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-main-R"
-                              style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                            >
-                              ]
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mo"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-main-R"
-                              style="margin-top: -0.144em; padding-bottom: 0.372em;"
-                            >
-                              .
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi MJXc-space1"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              s
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                            >
-                              i
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                            >
-                              z
-                            </span>
-                          </span>
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              e
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                do
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  13
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 index[
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m20"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="M"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                          >
-                            M
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ][
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m21"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="j"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ].calc_err(tmp_records[
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m22"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="M"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                          >
-                            M
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ][
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m23"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="j"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ]);
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline ltx_emph"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  14
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                if
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m24"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="index[M][j].max\\\\_abs\\\\_err>threshold"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            i
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            n
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                          >
-                            d
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            e
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            x
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                          >
-                            [
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                          >
-                            M
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                          >
-                            ]
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                          >
-                            [
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                          >
-                            ]
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="margin-top: -0.144em; padding-bottom: 0.372em;"
-                          >
-                            .
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi MJXc-space1"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            m
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            a
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            x
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="margin-top: -0.291em; padding-bottom: 0.372em;"
-                          >
-                            _
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            a
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            b
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            s
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="margin-top: -0.291em; padding-bottom: 0.372em;"
-                          >
-                            _
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            e
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            r
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            r
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mo MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-main-R"
-                            style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                          >
-                            &gt;
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi MJXc-space3"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.372em; padding-bottom: 0.298em;"
-                          >
-                            t
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            h
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            r
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            e
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            s
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            h
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                          >
-                            o
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                          >
-                            l
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                          >
-                            d
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                then
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  15
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 index[
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m25"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="M"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                          >
-                            M
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ][
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m26"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="j"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ] = new 
-              </span>
-              <span
-                class="ltx_ERROR undefined"
-              >
-                \\btree
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                trained on tmp_records[
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m27"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="M"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;"
-                          >
-                            M
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ][
-              </span>
-              <span
-                class="ltx_Math"
-                id="algorithm1.m28"
-              >
-                <span
-                  class="mjpage"
-                >
-                  <span
-                    class="mjx-chtml"
-                  >
-                    <span
-                      aria-label="j"
-                      class="mjx-math"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="mjx-mrow"
-                      >
-                        <span
-                          class="mjx-mi"
-                        >
-                          <span
-                            class="mjx-char MJXc-TeX-math-I"
-                            style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                          >
-                            j
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                ];
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  16
-                </span>
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                      
-              </span>
-              <span
-                class="ltx_rule"
-                style="width:1px;height:100%;background:black;display:inline-block;"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                    
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_listingline"
-              >
-                <span
-                  class="ltx_text"
-                  style="font-size:80%;"
-                >
-                  17
-                </span>
-              </span>
-              <span
-                class="ltx_text ltx_font_bold"
-                style="font-size:80%;"
-              >
-                return
-              </span>
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                 index;
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-            >
-              
-
-              <span
-                class="ltx_text"
-                style="font-size:80%;"
-              >
-                  
-              </span>
-              
-
-            </div>
-            
-
-          </div>
-          
-
-          <figcaption
-            class="ltx_caption"
-            style="font-size:80%;"
-          >
-            <span
-              class="ltx_tag ltx_tag_float"
-            >
-              <span
-                class="ltx_text ltx_font_bold"
-              >
-                Algorithm 1
-              </span>
-               
-            </span>
-            Hybrid End-To-End Training
-          </figcaption>
-          
-
-        </figure>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Algorithms</h2>
+
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Given an index configuration, which specifies the number of stages and the number of models per stage as an array of sizes, the end-to-end training for hybrid indexes is done as shown in Algorithm&nbsp;<a href=\\"#algorithm1\\" title=\\"Algorithm 1 ‣ 1 Algorithms\\" class=\\"ltx_ref\\"><span class=\\"ltx_text ltx_ref_tag\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">1</span></span></a></p>
 </div>
+<figure id=\\"algorithm1\\" class=\\"ltx_float\\">
+<div class=\\"ltx_listing ltx_lst_numbers_left ltx_listing\\">
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_text\\" style=\\"font-size:80%;\\"><span class=\\"ltx_text ltx_font_bold\\">Input:</span> </span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">int threshold, int stages[], NN_complexity</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"><span class=\\"ltx_text ltx_font_bold\\">Data:</span> </span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">record data[], Model index[][]</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"><span class=\\"ltx_text ltx_font_bold\\">Result:</span> </span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">trained index </span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">1</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span id=\\"algorithm1.m1\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"M\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> = stages.size;</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">2</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> tmp_records[][];</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">3</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> tmp_records[1][1] = all_data;</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">4</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">for</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span id=\\"algorithm1.m2\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"i\\\\leftarrow 1\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">←</span></span><span class=\\"mjx-mn MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span><span class=\\"ltx_text ltx_font_italic\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">to</span><span class=\\"ltx_text ltx_emph ltx_font_italic\\" style=\\"font-size:80%;\\"> <span id=\\"algorithm1.m3\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"M\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">do</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">5</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">for</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span id=\\"algorithm1.m4\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\\\leftarrow 1\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">←</span></span><span class=\\"mjx-mn MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span><span class=\\"ltx_text ltx_font_italic\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">to</span><span class=\\"ltx_text ltx_emph ltx_font_italic\\" style=\\"font-size:80%;\\"> <span id=\\"algorithm1.m5\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"stages[i]\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">s</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.372em; padding-bottom: 0.298em;\\">t</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">a</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;\\">g</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">s</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">[</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">]</span></span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">do</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">6</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> index[i][j] = new NN trained on tmp_records[</span><span id=\\"algorithm1.m6\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"i\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">][</span><span id=\\"algorithm1.m7\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">];</span>
+</div>
+<div class=\\"ltx_listingline ltx_emph\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">7</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">if</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span id=\\"algorithm1.m8\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"i<M\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">&lt;</span></span><span class=\\"mjx-mi MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">then</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">8</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">for</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span id=\\"algorithm1.m9\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"r\\\\in\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">r</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">∈</span></span></span></span></span></span></span><span class=\\"ltx_text ltx_emph ltx_font_italic\\" style=\\"font-size:80%;\\"> tmp_records[<span id=\\"algorithm1.m10\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"i\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span></span></span></span></span></span>][<span id=\\"algorithm1.m11\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span></span></span></span></span></span>]</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">do</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">9</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span id=\\"algorithm1.m12\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"p\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.446em;\\">p</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> = index[i][j]</span><span id=\\"algorithm1.m13\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"(r.key)\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">(</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">r</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"margin-top: -0.144em; padding-bottom: 0.372em;\\">.</span></span><span class=\\"mjx-mi MJXc-space1\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">k</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;\\">y</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">)</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> / stages[</span><span id=\\"algorithm1.m14\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"i+1\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">+</span></span><span class=\\"mjx-mn MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">];</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">10</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> tmp_records[</span><span id=\\"algorithm1.m15\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"i+1\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">+</span></span><span class=\\"mjx-mn MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">][</span><span id=\\"algorithm1.m16\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"p\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.446em;\\">p</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">].add(</span><span id=\\"algorithm1.m17\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"r\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">r</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">);</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">11</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">12</span></span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">for</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span id=\\"algorithm1.m18\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\\\leftarrow 1\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">←</span></span><span class=\\"mjx-mn MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span><span class=\\"ltx_text ltx_font_italic\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">to</span><span class=\\"ltx_text ltx_emph ltx_font_italic\\" style=\\"font-size:80%;\\"> <span id=\\"algorithm1.m19\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"index[M].size\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">n</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;\\">d</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">[</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">]</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"margin-top: -0.144em; padding-bottom: 0.372em;\\">.</span></span><span class=\\"mjx-mi MJXc-space1\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">s</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;\\">z</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">do</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">13</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> index[</span><span id=\\"algorithm1.m20\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"M\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">][</span><span id=\\"algorithm1.m21\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">].calc_err(tmp_records[</span><span id=\\"algorithm1.m22\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"M\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">][</span><span id=\\"algorithm1.m23\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">]);</span>
+</div>
+<div class=\\"ltx_listingline ltx_emph\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">14</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">if</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span id=\\"algorithm1.m24\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"index[M][j].max\\\\_abs\\\\_err>threshold\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">n</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;\\">d</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">[</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">]</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">[</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">]</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"margin-top: -0.144em; padding-bottom: 0.372em;\\">.</span></span><span class=\\"mjx-mi MJXc-space1\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">m</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">a</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"margin-top: -0.291em; padding-bottom: 0.372em;\\">_</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">a</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">b</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">s</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"margin-top: -0.291em; padding-bottom: 0.372em;\\">_</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">r</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">r</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">&gt;</span></span><span class=\\"mjx-mi MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.372em; padding-bottom: 0.298em;\\">t</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">h</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">r</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">s</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">h</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">o</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">l</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;\\">d</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;</span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">then</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">15</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> index[</span><span id=\\"algorithm1.m25\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"M\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">][</span><span id=\\"algorithm1.m26\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">] = new </span><span class=\\"ltx_ERROR undefined\\">\\\\btree</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">trained on tmp_records[</span><span id=\\"algorithm1.m27\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"M\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;\\">M</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">][</span><span id=\\"algorithm1.m28\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"j\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">j</span></span></span></span></span></span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">];</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">16</span></span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_rule\\" style=\\"width:1px;height:100%;background:black;display:inline-block;\\">&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> </span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_tag ltx_tag_listingline\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">17</span></span><span class=\\"ltx_text ltx_font_bold\\" style=\\"font-size:80%;\\">return</span><span class=\\"ltx_text\\" style=\\"font-size:80%;\\"> index;</span>
+</div>
+<div class=\\"ltx_listingline\\">
+<span class=\\"ltx_text\\" style=\\"font-size:80%;\\">  </span>
+</div>
+</div>
+<figcaption class=\\"ltx_caption\\" style=\\"font-size:80%;\\"><span class=\\"ltx_tag ltx_tag_float\\"><span class=\\"ltx_text ltx_font_bold\\">Algorithm&nbsp;1</span> </span>Hybrid End-To-End Training</figcaption>
+</figure>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`citations.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<div id=\\"p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Refer to <cite class=\\"ltx_cite ltx_citemacro_cite\\">[<a href=\\"#bib.bib1\\" title=\\"\\" class=\\"ltx_ref\\">1</a>]</cite> then refer to <cite class=\\"ltx_cite ltx_citemacro_cite\\">[<a href=\\"#bib.bib2\\" title=\\"\\" class=\\"ltx_ref\\">2</a>]</cite> but misspell <cite class=\\"ltx_cite ltx_citemacro_cite\\">[<span class=\\"ltx_ref ltx_missing_citation ltx_ref_self\\">zlateskiS15_asdf</span>]</cite></p>
+</div>
+<section id=\\"bib\\" class=\\"ltx_bibliography\\">
+<h2 class=\\"ltx_title ltx_title_bibliography\\">References</h2>
 
-  <div
-    class="ltx_page_content"
-  >
-    
+<ul class=\\"ltx_biblist\\">
+<li id=\\"bib.bib1\\" class=\\"ltx_bibitem\\">
+<span class=\\"ltx_tag ltx_tag_bibitem\\">[1]</span>
+<span class=\\"ltx_bibblock\\">
+S.&nbsp;C. Turaga, J.&nbsp;F. Murray, V.&nbsp;Jain, F.&nbsp;Roth, M.&nbsp;Helmstaedter, K.&nbsp;Briggman,
+W.&nbsp;Denk, and H.&nbsp;S. Seung.
 
-    <article
-      class="ltx_document"
-    >
-      
-
-      <div
-        class="ltx_para"
-        id="p1"
-      >
-        
-
-        <p
-          class="ltx_p"
-        >
-          Refer to 
-          <cite
-            class="ltx_cite ltx_citemacro_cite"
-          >
-            [
-            <a
-              class="ltx_ref"
-              href="#bib.bib1"
-              title=""
-            >
-              1
-            </a>
-            ]
-          </cite>
-           then refer to 
-          <cite
-            class="ltx_cite ltx_citemacro_cite"
-          >
-            [
-            <a
-              class="ltx_ref"
-              href="#bib.bib2"
-              title=""
-            >
-              2
-            </a>
-            ]
-          </cite>
-           but misspell 
-          <cite
-            class="ltx_cite ltx_citemacro_cite"
-          >
-            [
-            <span
-              class="ltx_ref ltx_missing_citation ltx_ref_self"
-            >
-              zlateskiS15_asdf
-            </span>
-            ]
-          </cite>
-        </p>
-        
-
-      </div>
-      
-
-      <section
-        class="ltx_bibliography"
-        id="bib"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_bibliography"
-        >
-          References
-        </h2>
-        
-
-
-        <ul
-          class="ltx_biblist"
-        >
-          
-
-          <li
-            class="ltx_bibitem"
-            id="bib.bib1"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_bibitem"
-            >
-              [1]
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              
-S. C. Turaga, J. F. Murray, V. Jain, F. Roth, M. Helmstaedter, K. Briggman,
-W. Denk, and H. S. Seung.
-
-
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              Convolutional networks can learn to generate affinity graphs for
+</span>
+<span class=\\"ltx_bibblock\\">Convolutional networks can learn to generate affinity graphs for
 image segmentation.
 
+</span>
+<span class=\\"ltx_bibblock\\"><span class=\\"ltx_text ltx_font_italic\\">Neural Comput.</span>, 22(2):511–538, Feb. 2010.
 
-            </span>
-            
+</span>
+</li>
+<li id=\\"bib.bib2\\" class=\\"ltx_bibitem\\">
+<span class=\\"ltx_tag ltx_tag_bibitem\\">[2]</span>
+<span class=\\"ltx_bibblock\\">
+A.&nbsp;Vazquez-Reina, M.&nbsp;Gelbart, D.&nbsp;Huang, J.&nbsp;Lichtman, E.&nbsp;Miller, and H.&nbsp;Pfister.
 
-            <span
-              class="ltx_bibblock"
-            >
-              <span
-                class="ltx_text ltx_font_italic"
-              >
-                Neural Comput.
-              </span>
-              , 22(2):511–538, Feb. 2010.
+</span>
+<span class=\\"ltx_bibblock\\">Segmentation fusion for connectomics.
 
+</span>
+<span class=\\"ltx_bibblock\\">In <span class=\\"ltx_text ltx_font_italic\\">ICCV</span>, 2011.
 
-            </span>
-            
+</span>
+</li>
+<li id=\\"bib.bib3\\" class=\\"ltx_bibitem\\">
+<span class=\\"ltx_tag ltx_tag_bibitem\\">[3]</span>
+<span class=\\"ltx_bibblock\\">
+A.&nbsp;Zlateski and H.&nbsp;S. Seung.
 
-          </li>
-          
-
-          <li
-            class="ltx_bibitem"
-            id="bib.bib2"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_bibitem"
-            >
-              [2]
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              
-A. Vazquez-Reina, M. Gelbart, D. Huang, J. Lichtman, E. Miller, and H. Pfister.
-
-
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              Segmentation fusion for connectomics.
-
-
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              In 
-              <span
-                class="ltx_text ltx_font_italic"
-              >
-                ICCV
-              </span>
-              , 2011.
-
-
-            </span>
-            
-
-          </li>
-          
-
-          <li
-            class="ltx_bibitem"
-            id="bib.bib3"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_bibitem"
-            >
-              [3]
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              
-A. Zlateski and H. S. Seung.
-
-
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              Image segmentation by size-dependent single linkage clustering of a
+</span>
+<span class=\\"ltx_bibblock\\">Image segmentation by size-dependent single linkage clustering of a
 watershed basin graph.
 
+</span>
+<span class=\\"ltx_bibblock\\"><span class=\\"ltx_text ltx_font_italic\\">CoRR</span>, abs/1505.00249, 2015.
 
-            </span>
-            
-
-            <span
-              class="ltx_bibblock"
-            >
-              <span
-                class="ltx_text ltx_font_italic"
-              >
-                CoRR
-              </span>
-              , abs/1505.00249, 2015.
-
-
-            </span>
-            
-
-          </li>
-          
-
-        </ul>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+</span>
+</li>
+</ul>
+</section>
+</article>
 </div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`figures.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Plain includeimage</h2>
 
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Plain includeimage
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <img
-            alt=""
-            class="ltx_graphics"
-            height="318"
-            id="S1.p1.g1"
-            src="fig.png"
-            width="300"
-          />
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S2"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            2 
-          </span>
-          Single image
-        </h2>
-        
-
-
-        <figure
-          class="ltx_figure"
-          id="S2.F1"
-        >
-          <img
-            alt=""
-            class="ltx_graphics"
-            height="301"
-            id="S2.F1.g1"
-            src="fig.png"
-            width="284"
-          />
-          
-
-          <figcaption
-            class="ltx_caption"
-          >
-            <span
-              class="ltx_tag ltx_tag_figure"
-            >
-              Figure 1: 
-            </span>
-            Fig.
-          </figcaption>
-          
-
-        </figure>
-        
-
-        <div
-          class="ltx_para"
-          id="S2.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            See fig 
-            <a
-              class="ltx_ref"
-              href="#S2.F2"
-              title="Figure 2 ‣ 2.1 Multiple images ‣ 2 Single image"
-            >
-              <span
-                class="ltx_text ltx_ref_tag"
-              >
-                2
-              </span>
-            </a>
-            .
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S2.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Ref which doesn’t exist 
-            <span
-              class="ltx_ref ltx_missing_label ltx_ref_self"
-            >
-              LABEL:fig:notexist
-            </span>
-            .
-          </p>
-          
-
-        </div>
-        
-
-        <section
-          class="ltx_subsection"
-          id="S2.SS1"
-        >
-          
-
-          <h3
-            class="ltx_title ltx_title_subsection"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_subsection"
-            >
-              2.1 
-            </span>
-            Multiple images
-          </h3>
-          
-
-
-          <figure
-            class="ltx_figure"
-            id="S2.F2"
-          >
-            
-
-            <table
-              style="width:100%;"
-            >
-              
-
-              <tbody>
-                <tr>
-                  
-
-                  <td
-                    class="ltx_subgraphics"
-                  >
-                    <img
-                      alt=""
-                      class="ltx_graphics"
-                      height="301"
-                      id="S2.F2.g1"
-                      src="fig.png"
-                      width="284"
-                    />
-                  </td>
-                  
-
-                  <td
-                    class="ltx_subgraphics"
-                  >
-                    <img
-                      alt=""
-                      class="ltx_graphics"
-                      height="301"
-                      id="S2.F2.g2"
-                      src="fig.png"
-                      width="284"
-                    />
-                  </td>
-                  
-
-                </tr>
-                
-
-              </tbody>
-            </table>
-            
-
-            <figcaption
-              class="ltx_caption"
-            >
-              <span
-                class="ltx_tag ltx_tag_figure"
-              >
-                Figure 2: 
-              </span>
-              Fig.
-            </figcaption>
-            
-
-          </figure>
-          
-
-          <div
-            class="ltx_para"
-            id="S2.SS1.p1"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              See fig 
-              <a
-                class="ltx_ref"
-                href="#S2.F2"
-                title="Figure 2 ‣ 2.1 Multiple images ‣ 2 Single image"
-              >
-                <span
-                  class="ltx_text ltx_ref_tag"
-                >
-                  2
-                </span>
-              </a>
-              .
-            </p>
-            
-
-          </div>
-          
-
-        </section>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<img src=\\"fig.png\\" id=\\"S1.p1.g1\\" class=\\"ltx_graphics\\" width=\\"300\\" height=\\"318\\" alt=\\"\\">
 </div>
+</section>
+<section id=\\"S2\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">2 </span>Single image</h2>
+
+<figure id=\\"S2.F1\\" class=\\"ltx_figure\\"><img src=\\"fig.png\\" id=\\"S2.F1.g1\\" class=\\"ltx_graphics\\" width=\\"284\\" height=\\"301\\" alt=\\"\\">
+<figcaption class=\\"ltx_caption\\"><span class=\\"ltx_tag ltx_tag_figure\\">Figure 1: </span>Fig.</figcaption>
+</figure>
+<div id=\\"S2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">See fig <a href=\\"#S2.F2\\" title=\\"Figure 2 ‣ 2.1 Multiple images ‣ 2 Single image\\" class=\\"ltx_ref\\"><span class=\\"ltx_text ltx_ref_tag\\">2</span></a>.</p>
+</div>
+<div id=\\"S2.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Ref which doesn’t exist <span class=\\"ltx_ref ltx_missing_label ltx_ref_self\\">LABEL:fig:notexist</span>.</p>
+</div>
+<section id=\\"S2.SS1\\" class=\\"ltx_subsection\\">
+<h3 class=\\"ltx_title ltx_title_subsection\\">
+<span class=\\"ltx_tag ltx_tag_subsection\\">2.1 </span>Multiple images</h3>
+
+<figure id=\\"S2.F2\\" class=\\"ltx_figure\\">
+<table style=\\"width:100%;\\">
+<tbody><tr>
+<td class=\\"ltx_subgraphics\\"><img src=\\"fig.png\\" id=\\"S2.F2.g1\\" class=\\"ltx_graphics\\" width=\\"284\\" height=\\"301\\" alt=\\"\\"></td>
+<td class=\\"ltx_subgraphics\\"><img src=\\"fig.png\\" id=\\"S2.F2.g2\\" class=\\"ltx_graphics\\" width=\\"284\\" height=\\"301\\" alt=\\"\\"></td>
+</tr>
+</tbody></table>
+<figcaption class=\\"ltx_caption\\"><span class=\\"ltx_tag ltx_tag_figure\\">Figure 2: </span>Fig.</figcaption>
+</figure>
+<div id=\\"S2.SS1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">See fig <a href=\\"#S2.F2\\" title=\\"Figure 2 ‣ 2.1 Multiple images ‣ 2 Single image\\" class=\\"ltx_ref\\"><span class=\\"ltx_text ltx_ref_tag\\">2</span></a>.</p>
+</div>
+</section>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`footnotes.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <div
-        class="ltx_para"
-        id="p1"
-      >
-        
-
-        <p
-          class="ltx_p"
-        >
-          This is some text.
-          <span
-            class="ltx_note ltx_role_footnote"
-            id="footnote1"
-          >
-            <sup
-              class="ltx_note_mark"
-            >
-              1
-            </sup>
-            <span
-              class="ltx_note_outer"
-            >
-              <span
-                class="ltx_note_content"
-              >
-                <sup
-                  class="ltx_note_mark"
-                >
-                  1
-                </sup>
-                <span
-                  class="ltx_tag ltx_tag_note"
-                >
-                  1
-                </span>
-                This is a footnote.
-              </span>
-            </span>
-          </span>
-           This is some more text.
-          <span
-            class="ltx_note ltx_role_footnote"
-            id="footnote2"
-          >
-            <sup
-              class="ltx_note_mark"
-            >
-              2
-            </sup>
-            <span
-              class="ltx_note_outer"
-            >
-              <span
-                class="ltx_note_content"
-              >
-                <sup
-                  class="ltx_note_mark"
-                >
-                  2
-                </sup>
-                <span
-                  class="ltx_tag ltx_tag_note"
-                >
-                  2
-                </span>
-                And a footnote with a
-second paragraph! And some 
-                <span
-                  class="ltx_text ltx_emph ltx_font_italic"
-                >
-                  formatting
-                </span>
-                .
-              </span>
-            </span>
-          </span>
-        </p>
-        
-
-      </div>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<div id=\\"p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is some text.<span id=\\"footnote1\\" class=\\"ltx_note ltx_role_footnote\\"><sup class=\\"ltx_note_mark\\">1</sup><span class=\\"ltx_note_outer\\"><span class=\\"ltx_note_content\\"><sup class=\\"ltx_note_mark\\">1</sup><span class=\\"ltx_tag ltx_tag_note\\">1</span>This is a footnote.</span></span></span> This is some more text.<span id=\\"footnote2\\" class=\\"ltx_note ltx_role_footnote\\"><sup class=\\"ltx_note_mark\\">2</sup><span class=\\"ltx_note_outer\\"><span class=\\"ltx_note_content\\"><sup class=\\"ltx_note_mark\\">2</sup><span class=\\"ltx_tag ltx_tag_note\\">2</span>And a footnote with a
+second paragraph! And some <span class=\\"ltx_text ltx_emph ltx_font_italic\\">formatting</span>.</span></span></span></p>
 </div>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`headings.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document ltx_authors_1line"
-    >
-      
-
-      <h1
-        class="ltx_title ltx_title_document"
-      >
-        Sections test
-      </h1>
-      
-
-      <div
-        class="ltx_authors"
-      >
-        
-
-        <span
-          class="ltx_creator ltx_role_author"
-        >
-          
-
-          <span
-            class="ltx_personname"
-          >
-            Carl Capybara 
-
-          </span>
-          <span
-            class="ltx_author_notes"
-          >
-            <span>
-              A thanks block
-            </span>
-          </span>
-        </span>
-        
-
-        <span
-          class="ltx_author_before"
-        >
-            
-        </span>
-        <span
-          class="ltx_creator ltx_role_author"
-        >
-          
-
-          <span
-            class="ltx_personname"
-          >
-            Walter Wombat
-
-          </span>
-        </span>
-        
-
-      </div>
-      
-
-      <div
-        class="ltx_date ltx_role_creation"
-      >
-        March 2018
-      </div>
-      
-
-
-      <div
-        class="ltx_abstract"
-      >
-        
-
-        <h6
-          class="ltx_title ltx_title_abstract"
-        >
-          Abstract
-        </h6>
-        
-
-        <p
-          class="ltx_p"
-        >
-          A test of titles, abstracts, and sections.
-        </p>
-        
-
-      </div>
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Sections
-        </h2>
-        
-
-
-        <section
-          class="ltx_subsection"
-          id="S1.SS1"
-        >
-          
-
-          <h3
-            class="ltx_title ltx_title_subsection"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_subsection"
-            >
-              1.1 
-            </span>
-            Subsection
-          </h3>
-          
-
-
-          <div
-            class="ltx_para"
-            id="S1.SS1.p1"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              Some content to ensure spacing is correct.
-            </p>
-            
-
-          </div>
-          
-
-        </section>
-        
-
-        <section
-          class="ltx_subsection"
-          id="S1.SSx1"
-        >
-          
-
-          <h3
-            class="ltx_title ltx_title_subsection"
-          >
-            Subsection without counter
-          </h3>
-          
-
-
-          <section
-            class="ltx_subsubsection"
-            id="S1.SSx1.SSS1"
-          >
-            
-
-            <h4
-              class="ltx_title ltx_title_subsubsection"
-            >
-              
-
-              <span
-                class="ltx_tag ltx_tag_subsubsection"
-              >
-                1.1.1 
-              </span>
-              Subsubsection
-            </h4>
-            
-
-
-            <div
-              class="ltx_para"
-              id="S1.SSx1.SSS1.p1"
-            >
-              
-
-              <p
-                class="ltx_p"
-              >
-                Some content to ensure spacing is correct.
-              </p>
-              
-
-            </div>
-            
-
-            <section
-              class="ltx_paragraph"
-              id="S1.SSx1.SSS1.Px1"
-            >
-              
-
-              <h5
-                class="ltx_title ltx_title_paragraph"
-              >
-                Paragraph heading
-              </h5>
-              
-
-
-              <div
-                class="ltx_para"
-                id="S1.SSx1.SSS1.Px1.p1"
-              >
-                
-
-                <p
-                  class="ltx_p"
-                >
-                  Really rather a long paragraph to demonstrate the fact that when you put a paragraph heading in front of a paragraph it is all on the same line.
-
-                </p>
-                
-
-              </div>
-              
-
-              <section
-                class="ltx_subparagraph"
-                id="S1.SSx1.SSS1.Px1.SPx1"
-              >
-                
-
-                <h6
-                  class="ltx_title ltx_title_subparagraph"
-                >
-                  Subparagraph heading
-                </h6>
-                
-
-
-                <div
-                  class="ltx_para"
-                  id="S1.SSx1.SSS1.Px1.SPx1.p1"
-                >
-                  
-
-                  <p
-                    class="ltx_p"
-                  >
-                    Really rather a long paragraph to demonstrate the fact that when you put a paragraph heading in front of a paragraph it is all on the same line.
-                  </p>
-                  
-
-                </div>
-                
-
-              </section>
-              
-
-            </section>
-            
-
-          </section>
-          
-
-        </section>
-        
-
-        <section
-          class="ltx_subsection"
-          id="S1.SS2"
-        >
-          
-
-          <h3
-            class="ltx_title ltx_title_subsection"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_subsection"
-            >
-              1.2 
-            </span>
-            A Heading in All Caps Should Be Converted to Title Case
-          </h3>
-          
-
-
-        </section>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document ltx_authors_1line\\">
+<h1 class=\\"ltx_title ltx_title_document\\">Sections test</h1>
+<div class=\\"ltx_authors\\">
+<span class=\\"ltx_creator ltx_role_author\\">
+<span class=\\"ltx_personname\\">Carl Capybara 
+</span><span class=\\"ltx_author_notes\\"><span>A thanks block</span></span></span>
+<span class=\\"ltx_author_before\\">  </span><span class=\\"ltx_creator ltx_role_author\\">
+<span class=\\"ltx_personname\\">Walter Wombat
+</span></span>
 </div>
+<div class=\\"ltx_date ltx_role_creation\\">March 2018</div>
+
+<div class=\\"ltx_abstract\\">
+<h6 class=\\"ltx_title ltx_title_abstract\\">Abstract</h6>
+<p class=\\"ltx_p\\">A test of titles, abstracts, and sections.</p>
+</div>
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Sections</h2>
+
+<section id=\\"S1.SS1\\" class=\\"ltx_subsection\\">
+<h3 class=\\"ltx_title ltx_title_subsection\\">
+<span class=\\"ltx_tag ltx_tag_subsection\\">1.1 </span>Subsection</h3>
+
+<div id=\\"S1.SS1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Some content to ensure spacing is correct.</p>
+</div>
+</section>
+<section id=\\"S1.SSx1\\" class=\\"ltx_subsection\\">
+<h3 class=\\"ltx_title ltx_title_subsection\\">Subsection without counter</h3>
+
+<section id=\\"S1.SSx1.SSS1\\" class=\\"ltx_subsubsection\\">
+<h4 class=\\"ltx_title ltx_title_subsubsection\\">
+<span class=\\"ltx_tag ltx_tag_subsubsection\\">1.1.1 </span>Subsubsection</h4>
+
+<div id=\\"S1.SSx1.SSS1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Some content to ensure spacing is correct.</p>
+</div>
+<section id=\\"S1.SSx1.SSS1.Px1\\" class=\\"ltx_paragraph\\">
+<h5 class=\\"ltx_title ltx_title_paragraph\\">Paragraph heading</h5>
+
+<div id=\\"S1.SSx1.SSS1.Px1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Really rather a long paragraph to demonstrate the fact that when you put a paragraph heading in front of a paragraph it is all on the same line.
+</p>
+</div>
+<section id=\\"S1.SSx1.SSS1.Px1.SPx1\\" class=\\"ltx_subparagraph\\">
+<h6 class=\\"ltx_title ltx_title_subparagraph\\">Subparagraph heading</h6>
+
+<div id=\\"S1.SSx1.SSS1.Px1.SPx1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Really rather a long paragraph to demonstrate the fact that when you put a paragraph heading in front of a paragraph it is all on the same line.</p>
+</div>
+</section>
+</section>
+</section>
+</section>
+<section id=\\"S1.SS2\\" class=\\"ltx_subsection\\">
+<h3 class=\\"ltx_title ltx_title_subsection\\">
+<span class=\\"ltx_tag ltx_tag_subsection\\">1.2 </span>A Heading in All Caps Should Be Converted to Title Case</h3>
+
+</section>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`listings.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Listings</h2>
 
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Listings
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Some text before.
-          </p>
-          
-
-          <div
-            class="ltx_listing ltx_lst_language_Pascal ltx_lstlisting ltx_listing"
-          >
-            
-
-            <div
-              class="ltx_listing_data"
-            >
-              <a
-                href="http://data:text/plain;base64,Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCnsgZG8gbm90aGluZyB9CmVuZDsKV3JpdGUoJ0Nhc2UgaW5zZW5zaXRpdmUgJyk7CldyaXRlKCdQYXNjYWwga2V5d29yZHMuJyk7"
-              >
-                ⬇
-              </a>
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-              id="lstnumberx1"
-            >
-              
-
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                for
-              </span>
-              <span
-                class="ltx_text ltx_lst_space"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_lst_identifier"
-              >
-                i
-              </span>
-              :=
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                maxint
-              </span>
-              <span
-                class="ltx_text ltx_lst_space"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                to
-              </span>
-              <span
-                class="ltx_text ltx_lst_space"
-              >
-                 
-              </span>
-              0
-              <span
-                class="ltx_text ltx_lst_space"
-              >
-                 
-              </span>
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                do
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-              id="lstnumberx2"
-            >
-              
-
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                begin
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-              id="lstnumberx3"
-            >
-              
-
-              <span
-                class="ltx_text ltx_lst_comment"
-              >
-                {
-                <span
-                  class="ltx_text ltx_lst_space ltx_font_italic"
-                >
-                   
-                </span>
-                <span
-                  class="ltx_text ltx_font_italic"
-                >
-                  do
-                  <span
-                    class="ltx_text ltx_lst_space"
-                  >
-                     
-                  </span>
-                  nothing
-                  <span
-                    class="ltx_text ltx_lst_space"
-                  >
-                     
-                  </span>
-                </span>
-                }
-              </span>
-              
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-              id="lstnumberx4"
-            >
-              
-
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                end
-              </span>
-              ;
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-              id="lstnumberx5"
-            >
-              
-
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                Write
-              </span>
-              (
-              <span
-                class="ltx_text ltx_lst_string"
-              >
-                ’Case
-                <span
-                  class="ltx_text ltx_lst_space"
-                >
-                  ␣
-                </span>
-                insensitive
-                <span
-                  class="ltx_text ltx_lst_space"
-                >
-                  ␣
-                </span>
-                ’
-              </span>
-              );
-
-            </div>
-            
-
-            <div
-              class="ltx_listingline"
-              id="lstnumberx6"
-            >
-              
-
-              <span
-                class="ltx_text ltx_lst_keyword ltx_font_bold"
-              >
-                Write
-              </span>
-              (
-              <span
-                class="ltx_text ltx_lst_string"
-              >
-                ’Pascal
-                <span
-                  class="ltx_text ltx_lst_space"
-                >
-                  ␣
-                </span>
-                keywords.’
-              </span>
-              );
-
-            </div>
-            
-
-          </div>
-          
-
-          <p
-            class="ltx_p"
-          >
-            Some text after.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Some text before.</p>
+<div class=\\"ltx_listing ltx_lst_language_Pascal ltx_lstlisting ltx_listing\\">
+<div class=\\"ltx_listing_data\\"><a href=\\"http://data:text/plain;base64,Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCnsgZG8gbm90aGluZyB9CmVuZDsKV3JpdGUoJ0Nhc2UgaW5zZW5zaXRpdmUgJyk7CldyaXRlKCdQYXNjYWwga2V5d29yZHMuJyk7\\">⬇</a></div>
+<div id=\\"lstnumberx1\\" class=\\"ltx_listingline\\">
+<span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">for</span><span class=\\"ltx_text ltx_lst_space\\">&nbsp;</span><span class=\\"ltx_text ltx_lst_identifier\\">i</span>:=<span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">maxint</span><span class=\\"ltx_text ltx_lst_space\\">&nbsp;</span><span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">to</span><span class=\\"ltx_text ltx_lst_space\\">&nbsp;</span>0<span class=\\"ltx_text ltx_lst_space\\">&nbsp;</span><span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">do</span>
 </div>
+<div id=\\"lstnumberx2\\" class=\\"ltx_listingline\\">
+<span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">begin</span>
+</div>
+<div id=\\"lstnumberx3\\" class=\\"ltx_listingline\\">
+<span class=\\"ltx_text ltx_lst_comment\\">{<span class=\\"ltx_text ltx_lst_space ltx_font_italic\\">&nbsp;</span><span class=\\"ltx_text ltx_font_italic\\">do<span class=\\"ltx_text ltx_lst_space\\">&nbsp;</span>nothing<span class=\\"ltx_text ltx_lst_space\\">&nbsp;</span></span>}</span>
+</div>
+<div id=\\"lstnumberx4\\" class=\\"ltx_listingline\\">
+<span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">end</span>;
+</div>
+<div id=\\"lstnumberx5\\" class=\\"ltx_listingline\\">
+<span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">Write</span>(<span class=\\"ltx_text ltx_lst_string\\">’Case<span class=\\"ltx_text ltx_lst_space\\">␣</span>insensitive<span class=\\"ltx_text ltx_lst_space\\">␣</span>’</span>);
+</div>
+<div id=\\"lstnumberx6\\" class=\\"ltx_listingline\\">
+<span class=\\"ltx_text ltx_lst_keyword ltx_font_bold\\">Write</span>(<span class=\\"ltx_text ltx_lst_string\\">’Pascal<span class=\\"ltx_text ltx_lst_space\\">␣</span>keywords.’</span>);
+</div>
+</div>
+<p class=\\"ltx_p\\">Some text after.</p>
+</div>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`lists.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <div
-        class="ltx_para"
-        id="p1"
-      >
-        
-
-        <ul
-          class="ltx_itemize"
-          id="S0.I1"
-        >
-          
-
-          <li
-            class="ltx_item"
-            id="S0.I1.i1"
-          >
-            
-
-            <div
-              class="ltx_para"
-              id="S0.I1.i1.p1"
-            >
-              
-
-              <p
-                class="ltx_p"
-              >
-                An unordered list
-              </p>
-              
-
-            </div>
-            
-
-          </li>
-          
-
-          <li
-            class="ltx_item"
-            id="S0.I1.i2"
-          >
-            
-
-            <div
-              class="ltx_para"
-              id="S0.I1.i2.p1"
-            >
-              
-
-              <p
-                class="ltx_p"
-              >
-                Second item
-              </p>
-              
-
-            </div>
-            
-
-          </li>
-          
-
-        </ul>
-        
-
-      </div>
-      
-
-      <div
-        class="ltx_para"
-        id="p2"
-      >
-        
-
-        <ol
-          class="ltx_enumerate"
-          id="S0.I2"
-        >
-          
-
-          <li
-            class="ltx_item"
-            id="S0.I2.i1"
-          >
-            
-
-            <div
-              class="ltx_para"
-              id="S0.I2.i1.p1"
-            >
-              
-
-              <p
-                class="ltx_p"
-              >
-                An ordered list
-              </p>
-              
-
-            </div>
-            
-
-          </li>
-          
-
-          <li
-            class="ltx_item"
-            id="S0.I2.i2"
-          >
-            
-
-            <div
-              class="ltx_para"
-              id="S0.I2.i2.p1"
-            >
-              
-
-              <p
-                class="ltx_p"
-              >
-                Second one.
-              </p>
-              
-
-            </div>
-            
-
-          </li>
-          
-
-        </ol>
-        
-
-      </div>
-      
-
-      <div
-        class="ltx_para"
-        id="p3"
-      >
-        
-
-        <ul
-          class="ltx_itemize"
-          id="S0.I3"
-        >
-          
-
-          <li
-            class="ltx_item"
-            id="S0.I3.i1"
-          >
-            
-
-            <div
-              class="ltx_para"
-              id="S0.I3.i1.p1"
-            >
-              
-
-              <p
-                class="ltx_p"
-              >
-                A nested unordered list
-              </p>
-              
-
-              <ul
-                class="ltx_itemize"
-                id="S0.I3.I1"
-              >
-                
-
-                <li
-                  class="ltx_item"
-                  id="S0.I3.i1.i1"
-                >
-                  
-
-                  <div
-                    class="ltx_para"
-                    id="S0.I3.i1.i1.p1"
-                  >
-                    
-
-                    <p
-                      class="ltx_p"
-                    >
-                      First nested item
-                    </p>
-                    
-
-                  </div>
-                  
-
-                </li>
-                
-
-                <li
-                  class="ltx_item"
-                  id="S0.I3.i1.i2"
-                >
-                  
-
-                  <div
-                    class="ltx_para"
-                    id="S0.I3.i1.i2.p1"
-                  >
-                    
-
-                    <p
-                      class="ltx_p"
-                    >
-                      Second nested item
-                    </p>
-                    
-
-                  </div>
-                  
-
-                </li>
-                
-
-              </ul>
-              
-
-            </div>
-            
-
-          </li>
-          
-
-          <li
-            class="ltx_item"
-            id="S0.I3.i2"
-          >
-            
-
-            <div
-              class="ltx_para"
-              id="S0.I3.i2.p1"
-            >
-              
-
-              <p
-                class="ltx_p"
-              >
-                Second item
-              </p>
-              
-
-            </div>
-            
-
-          </li>
-          
-
-        </ul>
-        
-
-      </div>
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          A nested ordered list
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <ol
-            class="ltx_enumerate"
-            id="S1.I1"
-          >
-            
-
-            <li
-              class="ltx_item"
-              id="S1.I1.i1"
-            >
-              
-
-              <div
-                class="ltx_para"
-                id="S1.I1.i1.p1"
-              >
-                
-
-                <p
-                  class="ltx_p"
-                >
-                  First item
-
-                </p>
-                
-
-                <ol
-                  class="ltx_enumerate"
-                  id="S1.I1.I1"
-                >
-                  
-
-                  <li
-                    class="ltx_item"
-                    id="S1.I1.i1.i1"
-                  >
-                    
-
-                    <div
-                      class="ltx_para"
-                      id="S1.I1.i1.i1.p1"
-                    >
-                      
-
-                      <p
-                        class="ltx_p"
-                      >
-                        First nested item
-                      </p>
-                      
-
-                    </div>
-                    
-
-                  </li>
-                  
-
-                  <li
-                    class="ltx_item"
-                    id="S1.I1.i1.i2"
-                  >
-                    
-
-                    <div
-                      class="ltx_para"
-                      id="S1.I1.i1.i2.p1"
-                    >
-                      
-
-                      <p
-                        class="ltx_p"
-                      >
-                        Second nested item
-                      </p>
-                      
-
-                    </div>
-                    
-
-                  </li>
-                  
-
-                </ol>
-                
-
-              </div>
-              
-
-            </li>
-            
-
-            <li
-              class="ltx_item"
-              id="S1.I1.i2"
-            >
-              
-
-              <div
-                class="ltx_para"
-                id="S1.I1.i2.p1"
-              >
-                
-
-                <p
-                  class="ltx_p"
-                >
-                  Second item
-                </p>
-                
-
-              </div>
-              
-
-            </li>
-            
-
-          </ol>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<div id=\\"p1\\" class=\\"ltx_para\\">
+<ul id=\\"S0.I1\\" class=\\"ltx_itemize\\">
+<li id=\\"S0.I1.i1\\" class=\\"ltx_item\\">
+<div id=\\"S0.I1.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">An unordered list</p>
 </div>
+</li>
+<li id=\\"S0.I1.i2\\" class=\\"ltx_item\\">
+<div id=\\"S0.I1.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Second item</p>
+</div>
+</li>
+</ul>
+</div>
+<div id=\\"p2\\" class=\\"ltx_para\\">
+<ol id=\\"S0.I2\\" class=\\"ltx_enumerate\\">
+<li id=\\"S0.I2.i1\\" class=\\"ltx_item\\">
+<div id=\\"S0.I2.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">An ordered list</p>
+</div>
+</li>
+<li id=\\"S0.I2.i2\\" class=\\"ltx_item\\">
+<div id=\\"S0.I2.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Second one.</p>
+</div>
+</li>
+</ol>
+</div>
+<div id=\\"p3\\" class=\\"ltx_para\\">
+<ul id=\\"S0.I3\\" class=\\"ltx_itemize\\">
+<li id=\\"S0.I3.i1\\" class=\\"ltx_item\\">
+<div id=\\"S0.I3.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">A nested unordered list</p>
+<ul id=\\"S0.I3.I1\\" class=\\"ltx_itemize\\">
+<li id=\\"S0.I3.i1.i1\\" class=\\"ltx_item\\">
+<div id=\\"S0.I3.i1.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">First nested item</p>
+</div>
+</li>
+<li id=\\"S0.I3.i1.i2\\" class=\\"ltx_item\\">
+<div id=\\"S0.I3.i1.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Second nested item</p>
+</div>
+</li>
+</ul>
+</div>
+</li>
+<li id=\\"S0.I3.i2\\" class=\\"ltx_item\\">
+<div id=\\"S0.I3.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Second item</p>
+</div>
+</li>
+</ul>
+</div>
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>A nested ordered list</h2>
+
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<ol id=\\"S1.I1\\" class=\\"ltx_enumerate\\">
+<li id=\\"S1.I1.i1\\" class=\\"ltx_item\\">
+<div id=\\"S1.I1.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">First item
+</p>
+<ol id=\\"S1.I1.I1\\" class=\\"ltx_enumerate\\">
+<li id=\\"S1.I1.i1.i1\\" class=\\"ltx_item\\">
+<div id=\\"S1.I1.i1.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">First nested item</p>
+</div>
+</li>
+<li id=\\"S1.I1.i1.i2\\" class=\\"ltx_item\\">
+<div id=\\"S1.I1.i1.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Second nested item</p>
+</div>
+</li>
+</ol>
+</div>
+</li>
+<li id=\\"S1.I1.i2\\" class=\\"ltx_item\\">
+<div id=\\"S1.I1.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Second item</p>
+</div>
+</li>
+</ol>
+</div>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`math.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Block</h2>
 
-  <div
-    class="ltx_page_content"
-  >
-    
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<table id=\\"S1.E1\\" class=\\"ltx_equation ltx_eqn_table\\">
 
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Block
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <table
-            class="ltx_equation ltx_eqn_table"
-            id="S1.E1"
-          >
-            
-
-
-            <tbody>
-              <tr
-                class="ltx_equation ltx_eqn_row ltx_align_baseline"
-              >
-                
-
-                <td
-                  class="ltx_eqn_cell ltx_eqn_center_padleft"
-                />
-                
-
-                <td
-                  class="ltx_eqn_cell ltx_align_center"
-                >
-                  <span
-                    class="ltx_DisplayMath"
-                    id="S1.E1.m1"
-                  >
-                    <span
-                      class="mjpage mjpage__block"
-                    >
-                      <span
-                        class="mjx-chtml MJXc-display"
-                        style="text-align: left;"
-                      >
-                        <span
-                          aria-label=" e^{i\\\\pi}=-1 "
-                          class="mjx-math"
-                        >
-                          <span
-                            aria-hidden="true"
-                            class="mjx-mrow"
-                          >
-                            <span
-                              class="mjx-msubsup"
-                            >
-                              <span
-                                class="mjx-base"
-                              >
-                                <span
-                                  class="mjx-mi"
-                                >
-                                  <span
-                                    class="mjx-char MJXc-TeX-math-I"
-                                    style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                  >
-                                    e
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-sup"
-                                style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;"
-                              >
-                                <span
-                                  class="mjx-texatom"
-                                  style=""
-                                >
-                                  <span
-                                    class="mjx-mrow"
-                                  >
-                                    <span
-                                      class="mjx-mi"
-                                    >
-                                      <span
-                                        class="mjx-char MJXc-TeX-math-I"
-                                        style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                      >
-                                        i
-                                      </span>
-                                    </span>
-                                    <span
-                                      class="mjx-mi"
-                                    >
-                                      <span
-                                        class="mjx-char MJXc-TeX-math-I"
-                                        style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                                      >
-                                        π
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mo MJXc-space3"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.077em; padding-bottom: 0.298em;"
-                              >
-                                =
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mo MJXc-space3"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                              >
-                                −
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mn"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                              >
-                                1
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </td>
-                
-
-                <td
-                  class="ltx_eqn_cell ltx_eqn_center_padright"
-                />
-                
-
-                <td
-                  class="ltx_eqn_cell ltx_eqn_eqno ltx_align_middle ltx_align_right"
-                  rowspan="1"
-                >
-                  <span
-                    class="ltx_tag ltx_tag_equation ltx_align_right"
-                  >
-                    (1)
-                  </span>
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-          </table>
-          
-
-          <p
-            class="ltx_p"
-          >
-            Equation 
-            <a
-              class="ltx_ref"
-              href="#S1.E1"
-              title="(1) ‣ 1 Block"
-            >
-              <span
-                class="ltx_text ltx_ref_tag"
-              >
-                1
-              </span>
-            </a>
-             is some good math.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S2"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            2 
-          </span>
-          Inline
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S2.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            some lovely maths 
-            <span
-              class="ltx_Math"
-              id="S2.p1.m1"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="x^{2}+y^{2}=z^{2}"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-msubsup"
-                      >
-                        <span
-                          class="mjx-base"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              x
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sup"
-                          style="font-size: 70.7%; vertical-align: 0.513em; padding-left: 0px; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mn"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                >
-                                  2
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space2"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                        >
-                          +
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup MJXc-space2"
-                      >
-                        <span
-                          class="mjx-base"
-                          style="margin-right: -0.006em;"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;"
-                            >
-                              y
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sup"
-                          style="font-size: 70.7%; vertical-align: 0.513em; padding-left: 0.082em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mn"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                >
-                                  2
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space3"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.077em; padding-bottom: 0.298em;"
-                        >
-                          =
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup MJXc-space3"
-                      >
-                        <span
-                          class="mjx-base"
-                          style="margin-right: -0.003em;"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                            >
-                              z
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sup"
-                          style="font-size: 70.7%; vertical-align: 0.513em; padding-left: 0.076em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mn"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                >
-                                  2
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+<tbody><tr class=\\"ltx_equation ltx_eqn_row ltx_align_baseline\\">
+<td class=\\"ltx_eqn_cell ltx_eqn_center_padleft\\"></td>
+<td class=\\"ltx_eqn_cell ltx_align_center\\"><span id=\\"S1.E1.m1\\" class=\\"ltx_DisplayMath\\"><span class=\\"mjpage mjpage__block\\"><span class=\\"mjx-chtml MJXc-display\\" style=\\"text-align: left;\\"><span class=\\"mjx-math\\" aria-label=\\" e^{i\\\\pi}=-1 \\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">e</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;\\">π</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.077em; padding-bottom: 0.298em;\\">=</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">−</span></span><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span></td>
+<td class=\\"ltx_eqn_cell ltx_eqn_center_padright\\"></td>
+<td rowspan=\\"1\\" class=\\"ltx_eqn_cell ltx_eqn_eqno ltx_align_middle ltx_align_right\\"><span class=\\"ltx_tag ltx_tag_equation ltx_align_right\\">(1)</span></td>
+</tr>
+</tbody></table>
+<p class=\\"ltx_p\\">Equation&nbsp;<a href=\\"#S1.E1\\" title=\\"(1) ‣ 1 Block\\" class=\\"ltx_ref\\"><span class=\\"ltx_text ltx_ref_tag\\">1</span></a> is some good math.</p>
 </div>
+</section>
+<section id=\\"S2\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">2 </span>Inline</h2>
+
+<div id=\\"S2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">some lovely maths <span id=\\"S2.p1.m1\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"x^{2}+y^{2}=z^{2}\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.513em; padding-left: 0px; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">+</span></span><span class=\\"mjx-msubsup MJXc-space2\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.006em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;\\">y</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.513em; padding-left: 0.082em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.077em; padding-bottom: 0.298em;\\">=</span></span><span class=\\"mjx-msubsup MJXc-space3\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.003em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;\\">z</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.513em; padding-left: 0.076em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span></span></span></span></span></span></span></span></span></span></p>
+</div>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`paragraph.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Justification</h2>
 
-  <div
-    class="ltx_page_content"
-  >
-    
+<div id=\\"S1.p1\\" class=\\"ltx_para ltx_align_left\\">
+<p class=\\"ltx_p\\">Some text flushed left.</p>
+</div>
+<div id=\\"S1.p2\\" class=\\"ltx_para ltx_align_right\\">
+<p class=\\"ltx_p\\">Some text flushed right.</p>
+</div>
+<div id=\\"S1.p3\\" class=\\"ltx_para ltx_align_center\\">
+<p class=\\"ltx_p\\">Some text centered.</p>
+</div>
+</section>
+<section id=\\"S2\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">2 </span>Indentation</h2>
 
-    <article
-      class="ltx_document"
-    >
-      
+<div id=\\"S2.p1\\" class=\\"ltx_para ltx_indent\\">
+<p class=\\"ltx_p\\">This is indented.</p>
+</div>
+</section>
+<section id=\\"S3\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">3 </span>indentfirst package</h2>
 
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
+<div id=\\"S3.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">TODO</p>
+</div>
+</section>
+<section id=\\"S4\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">4 </span>parskip package</h2>
 
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
+<div id=\\"S4.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">TODO</p>
+</div>
+</section>
+<section id=\\"S5\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">5 </span>Verbatim</h2>
 
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Justification
-        </h2>
-        
-
-
-        <div
-          class="ltx_para ltx_align_left"
-          id="S1.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Some text flushed left.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para ltx_align_right"
-          id="S1.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Some text flushed right.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para ltx_align_center"
-          id="S1.p3"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Some text centered.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S2"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            2 
-          </span>
-          Indentation
-        </h2>
-        
-
-
-        <div
-          class="ltx_para ltx_indent"
-          id="S2.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            This is indented.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S3"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            3 
-          </span>
-          indentfirst package
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S3.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            TODO
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S4"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            4 
-          </span>
-          parskip package
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S4.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            TODO
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S5"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            5 
-          </span>
-          Verbatim
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S5.p1"
-        >
-          
-
-          <pre
-            class="ltx_verbatim ltx_font_typewriter"
-          >
-              The verbatim environment
+<div id=\\"S5.p1\\" class=\\"ltx_para\\">
+<pre class=\\"ltx_verbatim ltx_font_typewriter\\">  The verbatim environment
     simply reproduces every
    character you input,
   including all  s p a c e s!
   
-
-          </pre>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S5.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            The 
-            <code
-              class="ltx_verbatim ltx_font_typewriter"
-            >
-              verb command
-            </code>
-             can be used to make text within a paragraph monospace.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+</pre>
 </div>
+<div id=\\"S5.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">The <code class=\\"ltx_verbatim ltx_font_typewriter\\">verb command</code> can be used to make text within a paragraph monospace.</p>
+</div>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`sample2e.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document ltx_authors_1line\\">
+<h1 class=\\"ltx_title ltx_title_document\\">An Example Document</h1>
+<div class=\\"ltx_authors\\">
+<span class=\\"ltx_creator ltx_role_author\\">
+<span class=\\"ltx_personname\\">Leslie Lamport
+</span></span>
+</div>
+<div class=\\"ltx_date ltx_role_creation\\">January 21, 1994</div>
 
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document ltx_authors_1line"
-    >
-      
-
-      <h1
-        class="ltx_title ltx_title_document"
-      >
-        An Example Document
-      </h1>
-      
-
-      <div
-        class="ltx_authors"
-      >
-        
-
-        <span
-          class="ltx_creator ltx_role_author"
-        >
-          
-
-          <span
-            class="ltx_personname"
-          >
-            Leslie Lamport
-
-          </span>
-        </span>
-        
-
-      </div>
-      
-
-      <div
-        class="ltx_date ltx_role_creation"
-      >
-        January 21, 1994
-      </div>
-      
-
-
-      <div
-        class="ltx_para"
-        id="p1"
-      >
-        
-
-        <p
-          class="ltx_p"
-        >
-          This is an example input file. Comparing it with
+<div id=\\"p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is an example input file. Comparing it with
 the output it generates can show you how to
-produce a simple document of your own.
-        </p>
-        
+produce a simple document of your own.</p>
+</div>
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Ordinary Text</h2>
 
-      </div>
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Ordinary Text
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            The ends of words and sentences are marked
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">The ends of words and sentences are marked
 by spaces. It doesn’t matter how many
 spaces you type; one is as good as 100. The
-end of a line counts as a space.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            One or more blank lines denote the end
-of a paragraph.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p3"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Since any number of consecutive spaces are treated
+end of a line counts as a space.</p>
+</div>
+<div id=\\"S1.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">One or more blank lines denote the end
+of a paragraph.</p>
+</div>
+<div id=\\"S1.p3\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Since any number of consecutive spaces are treated
 like a single one, the formatting of the input
 file makes no difference to
 LaTeX, but it makes a difference to you. When you use
@@ -7510,23 +708,10 @@ LaTeX, making your input file as easy to read
 as possible will be a great help as you write
 your document and when you change it. This sample
 file shows how you can add comments to your own input
-file.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p4"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Because printing is different from typewriting,
+file.</p>
+</div>
+<div id=\\"S1.p4\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Because printing is different from typewriting,
 there are a number of things that you have to do
 differently when preparing an input file than if
 you were just typing the document directly.
@@ -7535,5882 +720,956 @@ Quotation marks like
 have to be handled specially, as do quotes within
 quotes:
 “ ‘this’ is what I just
-wrote, not ‘that’ ”.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p5"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Dashes come in three sizes: an
+wrote, not ‘that’ ”.</p>
+</div>
+<div id=\\"S1.p5\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Dashes come in three sizes: an
 intra-word
 dash, a medium dash for number ranges like
 1–2,
 and a punctuation
 dash—like
-this.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p6"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            A sentence-ending space should be larger than the
+this.</p>
+</div>
+<div id=\\"S1.p6\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">A sentence-ending space should be larger than the
 space between words within a sentence. You
 sometimes have to type special commands in
 conjunction with punctuation characters to get
 this right, as in the following sentence.
-Gnats, gnus, etc. all begin with G. You should check the spaces after periods when
+Gnats, gnus, etc.&nbsp;all begin with G. You should check the spaces after periods when
 reading your output to make sure you haven’t
 forgotten any special cases. Generating an
 ellipsis
-… with the right spacing around the periods requires
-a special command.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p7"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            LaTeX interprets some common characters as
+…&nbsp;with the right spacing around the periods requires
+a special command.</p>
+</div>
+<div id=\\"S1.p7\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">LaTeX&nbsp;interprets some common characters as
 commands, so you must type special commands to
 generate them. These characters include the
 following:
-$ & % # { and }.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p8"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            In printing, text is usually emphasized with an
-
-            <span
-              class="ltx_text ltx_emph ltx_font_italic"
-            >
-              italic
-            </span>
-            
-type style.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p9"
-        >
-          
-
-          <p
-            class="ltx_p ltx_emph"
-          >
-            <span
-              class="ltx_text ltx_font_italic"
-            >
-              A long segment of text can also be emphasized
+$ &amp; % # { and }.</p>
+</div>
+<div id=\\"S1.p8\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">In printing, text is usually emphasized with an
+<span class=\\"ltx_text ltx_emph ltx_font_italic\\">italic</span>
+type style.</p>
+</div>
+<div id=\\"S1.p9\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p ltx_emph\\"><span class=\\"ltx_text ltx_font_italic\\">A long segment of text can also be emphasized
 in this way. Text within such a segment can be
-given 
-            </span>
-            additional
-            <span
-              class="ltx_text ltx_font_italic"
-            >
-               emphasis.
-
-            </span>
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p10"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            It is sometimes necessary to prevent LaTeX from
+given </span>additional<span class=\\"ltx_text ltx_font_italic\\"> emphasis.
+</span></p>
+</div>
+<div id=\\"S1.p10\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">It is sometimes necessary to prevent LaTeX&nbsp;from
 breaking a line where it might otherwise do so.
-This may be at a space, as between the “Mr.” and
+This may be at a space, as between the “Mr.”&nbsp;and
 “Jones” in
-“Mr. Jones”, or within a word—especially when the word is a
+“Mr.&nbsp;Jones”, or within a word—especially when the word is a
 symbol like
-
-            <span
-              class="ltx_text ltx_emph ltx_font_italic"
-            >
-              itemnum
-            </span>
-            
+<span class=\\"ltx_text ltx_emph ltx_font_italic\\">itemnum</span>
 that makes little sense when hyphenated across
-lines.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p11"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Footnotes
-            <span
-              class="ltx_note ltx_role_footnote"
-              id="footnote1"
-            >
-              <sup
-                class="ltx_note_mark"
-              >
-                1
-              </sup>
-              <span
-                class="ltx_note_outer"
-              >
-                <span
-                  class="ltx_note_content"
-                >
-                  <sup
-                    class="ltx_note_mark"
-                  >
-                    1
-                  </sup>
-                  <span
-                    class="ltx_tag ltx_tag_note"
-                  >
-                    1
-                  </span>
-                  This is an example of a footnote.
-                </span>
-              </span>
-            </span>
-            
-pose no problem.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p12"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            LaTeX is good at typesetting mathematical formulas
+lines.</p>
+</div>
+<div id=\\"S1.p11\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Footnotes<span id=\\"footnote1\\" class=\\"ltx_note ltx_role_footnote\\"><sup class=\\"ltx_note_mark\\">1</sup><span class=\\"ltx_note_outer\\"><span class=\\"ltx_note_content\\"><sup class=\\"ltx_note_mark\\">1</sup><span class=\\"ltx_tag ltx_tag_note\\">1</span>This is an example of a footnote.</span></span></span>
+pose no problem.</p>
+</div>
+<div id=\\"S1.p12\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">LaTeX&nbsp;is good at typesetting mathematical formulas
 like
-
-            <span
-              class="ltx_Math"
-              id="S1.p12.m1"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="x-3y+z=7"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                        >
-                          x
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space2"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                        >
-                          −
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mn MJXc-space2"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                        >
-                          3
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;"
-                        >
-                          y
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space2"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                        >
-                          +
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mi MJXc-space2"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                        >
-                          z
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space3"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.077em; padding-bottom: 0.298em;"
-                        >
-                          =
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mn MJXc-space3"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                        >
-                          7
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-            
+<span id=\\"S1.p12.m1\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"x-3y+z=7\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">−</span></span><span class=\\"mjx-mn MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">3</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;\\">y</span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">+</span></span><span class=\\"mjx-mi MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;\\">z</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.077em; padding-bottom: 0.298em;\\">=</span></span><span class=\\"mjx-mn MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">7</span></span></span></span></span></span></span>
 or
-
-            <span
-              class="ltx_Math"
-              id="S1.p12.m2"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="a_{1}>x^{2n}+y^{2n}>x^{\\\\prime}"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-msubsup"
-                      >
-                        <span
-                          class="mjx-base"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              a
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sub"
-                          style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mn"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                >
-                                  1
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space3"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                        >
-                          &gt;
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup MJXc-space3"
-                      >
-                        <span
-                          class="mjx-base"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              x
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sup"
-                          style="font-size: 70.7%; vertical-align: 0.513em; padding-left: 0px; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mn"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                >
-                                  2
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                >
-                                  n
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space2"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                        >
-                          +
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup MJXc-space2"
-                      >
-                        <span
-                          class="mjx-base"
-                          style="margin-right: -0.006em;"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;"
-                            >
-                              y
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sup"
-                          style="font-size: 70.7%; vertical-align: 0.513em; padding-left: 0.082em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mn"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                >
-                                  2
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                >
-                                  n
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space3"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.225em; padding-bottom: 0.372em;"
-                        >
-                          &gt;
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup MJXc-space3"
-                      >
-                        <span
-                          class="mjx-base"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              x
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sup"
-                          style="font-size: 70.7%; vertical-align: 0.513em; padding-left: 0px; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-main-R"
-                                  style="padding-top: 0.298em; padding-bottom: 0.298em;"
-                                >
-                                  ′
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-            
+<span id=\\"S1.p12.m2\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"a_{1}>x^{2n}+y^{2n}>x^{\\\\prime}\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">a</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">&gt;</span></span><span class=\\"mjx-msubsup MJXc-space3\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.513em; padding-left: 0px; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">n</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">+</span></span><span class=\\"mjx-msubsup MJXc-space2\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.006em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;\\">y</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.513em; padding-left: 0.082em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">n</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.225em; padding-bottom: 0.372em;\\">&gt;</span></span><span class=\\"mjx-msubsup MJXc-space3\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.513em; padding-left: 0px; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.298em;\\">′</span></span></span></span></span></span></span></span></span></span></span>
 or
-
-            <span
-              class="ltx_Math"
-              id="S1.p12.m3"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="(A,B)=\\\\sum_{i}a_{i}b_{i}"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mo"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                        >
-                          (
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.519em; padding-bottom: 0.298em;"
-                        >
-                          A
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="margin-top: -0.144em; padding-bottom: 0.519em;"
-                        >
-                          ,
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mi MJXc-space1"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                        >
-                          B
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                        >
-                          )
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mo MJXc-space3"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.077em; padding-bottom: 0.298em;"
-                        >
-                          =
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-munderover MJXc-space3"
-                      >
-                        <span
-                          class="mjx-base"
-                        >
-                          <span
-                            class="mjx-mo"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-size1-R"
-                              style="padding-top: 0.519em; padding-bottom: 0.519em;"
-                            >
-                              ∑
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sub"
-                          style="font-size: 70.7%; vertical-align: -0.439em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                >
-                                  i
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup MJXc-space1"
-                      >
-                        <span
-                          class="mjx-base"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                            >
-                              a
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sub"
-                          style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                >
-                                  i
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-msubsup"
-                      >
-                        <span
-                          class="mjx-base"
-                        >
-                          <span
-                            class="mjx-mi"
-                          >
-                            <span
-                              class="mjx-char MJXc-TeX-math-I"
-                              style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                            >
-                              b
-                            </span>
-                          </span>
-                        </span>
-                        <span
-                          class="mjx-sub"
-                          style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"
-                        >
-                          <span
-                            class="mjx-texatom"
-                            style=""
-                          >
-                            <span
-                              class="mjx-mrow"
-                            >
-                              <span
-                                class="mjx-mi"
-                              >
-                                <span
-                                  class="mjx-char MJXc-TeX-math-I"
-                                  style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                >
-                                  i
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-            .
+<span id=\\"S1.p12.m3\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"(A,B)=\\\\sum_{i}a_{i}b_{i}\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">(</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.519em; padding-bottom: 0.298em;\\">A</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"margin-top: -0.144em; padding-bottom: 0.519em;\\">,</span></span><span class=\\"mjx-mi MJXc-space1\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">B</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">)</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.077em; padding-bottom: 0.298em;\\">=</span></span><span class=\\"mjx-munderover MJXc-space3\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-size1-R\\" style=\\"padding-top: 0.519em; padding-bottom: 0.519em;\\">∑</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.439em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span></span></span></span></span><span class=\\"mjx-msubsup MJXc-space1\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">a</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span></span></span></span></span><span class=\\"mjx-msubsup\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">b</span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span></span></span></span></span></span></span></span></span></span>.
 The spaces you type in a formula are
 ignored. Remember that a letter like
+<span id=\\"S1.p12.m4\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"x\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span></span></span></span></span></span> is a formula when it denotes a mathematical
+symbol, and it should be typed as one.</p>
+</div>
+</section>
+<section id=\\"S2\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">2 </span>Displayed Text</h2>
 
-            <span
-              class="ltx_Math"
-              id="S1.p12.m4"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="x"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mi"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-math-I"
-                          style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                        >
-                          x
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-             is a formula when it denotes a mathematical
-symbol, and it should be typed as one.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S2"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            2 
-          </span>
-          Displayed Text
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S2.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Text is displayed by indenting it from the left
+<div id=\\"S2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Text is displayed by indenting it from the left
 margin. Quotations are commonly displayed. There
-are short quotations
-          </p>
-          
-
-          <blockquote
-            class="ltx_quote"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              This is a short quotation. It consists of a
-single paragraph of text. See how it is formatted.
-            </p>
-            
-
-          </blockquote>
-          
-
-          <p
-            class="ltx_p"
-          >
-            and longer ones.
-          </p>
-          
-
-          <blockquote
-            class="ltx_quote"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              This is a longer quotation. It consists of two
+are short quotations</p>
+<blockquote class=\\"ltx_quote\\">
+<p class=\\"ltx_p\\">This is a short quotation. It consists of a
+single paragraph of text. See how it is formatted.</p>
+</blockquote>
+<p class=\\"ltx_p\\">and longer ones.</p>
+<blockquote class=\\"ltx_quote\\">
+<p class=\\"ltx_p\\">This is a longer quotation. It consists of two
 paragraphs of text, neither of which are
 particularly interesting.
 
-
-              <br
-                class="ltx_break"
-              />
-              
+<br class=\\"ltx_break\\">
 This is the second paragraph of the quotation. It
-is just as dull as the first paragraph.
-            </p>
-            
-
-          </blockquote>
-          
-
-          <p
-            class="ltx_p"
-          >
-            Another frequently-displayed structure is a list.
-The following is an example of an 
-            <span
-              class="ltx_text ltx_emph ltx_font_italic"
-            >
-              itemized
-            </span>
-            
-list.
-          </p>
-          
-
-          <ul
-            class="ltx_itemize"
-            id="S2.I1"
-          >
-            
-
-            <li
-              class="ltx_item"
-              id="S2.I1.i1"
-            >
-              
-
-              <div
-                class="ltx_para"
-                id="S2.I1.i1.p1"
-              >
-                
-
-                <p
-                  class="ltx_p"
-                >
-                  This is the first item of an itemized list.
+is just as dull as the first paragraph.</p>
+</blockquote>
+<p class=\\"ltx_p\\">Another frequently-displayed structure is a list.
+The following is an example of an <span class=\\"ltx_text ltx_emph ltx_font_italic\\">itemized</span>
+list.</p>
+<ul id=\\"S2.I1\\" class=\\"ltx_itemize\\">
+<li id=\\"S2.I1.i1\\" class=\\"ltx_item\\">
+<div id=\\"S2.I1.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is the first item of an itemized list.
 Each item in the list is marked with a “tick”.
 You don’t have to worry about what kind of tick
-mark is used.
-                </p>
-                
-
-              </div>
-              
-
-            </li>
-            
-
-            <li
-              class="ltx_item"
-              id="S2.I1.i2"
-            >
-              
-
-              <div
-                class="ltx_para"
-                id="S2.I1.i2.p1"
-              >
-                
-
-                <p
-                  class="ltx_p"
-                >
-                  This is the second item of the list. It
+mark is used.</p>
+</div>
+</li>
+<li id=\\"S2.I1.i2\\" class=\\"ltx_item\\">
+<div id=\\"S2.I1.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is the second item of the list. It
 contains another list nested inside it. The inner
-list is an 
-                  <span
-                    class="ltx_text ltx_emph ltx_font_italic"
-                  >
-                    enumerated
-                  </span>
-                   list.
-                </p>
-                
-
-                <ol
-                  class="ltx_enumerate"
-                  id="S2.I2"
-                >
-                  
-
-                  <li
-                    class="ltx_item"
-                    id="S2.I2.i1"
-                  >
-                    
-
-                    <div
-                      class="ltx_para"
-                      id="S2.I2.i1.p1"
-                    >
-                      
-
-                      <p
-                        class="ltx_p"
-                      >
-                        This is the first item of an enumerated
-list that is nested within the itemized list.
-                      </p>
-                      
-
-                    </div>
-                    
-
-                  </li>
-                  
-
-                  <li
-                    class="ltx_item"
-                    id="S2.I2.i2"
-                  >
-                    
-
-                    <div
-                      class="ltx_para"
-                      id="S2.I2.i2.p1"
-                    >
-                      
-
-                      <p
-                        class="ltx_p"
-                      >
-                        This is the second item of the inner list.
-LaTeX allows you to nest lists deeper than
-you really should.
-                      </p>
-                      
-
-                    </div>
-                    
-
-                  </li>
-                  
-
-                </ol>
-                
-
-                <p
-                  class="ltx_p"
-                >
-                  This is the rest of the second item of the outer
+list is an <span class=\\"ltx_text ltx_emph ltx_font_italic\\">enumerated</span> list.</p>
+<ol id=\\"S2.I2\\" class=\\"ltx_enumerate\\">
+<li id=\\"S2.I2.i1\\" class=\\"ltx_item\\">
+<div id=\\"S2.I2.i1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is the first item of an enumerated
+list that is nested within the itemized list.</p>
+</div>
+</li>
+<li id=\\"S2.I2.i2\\" class=\\"ltx_item\\">
+<div id=\\"S2.I2.i2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is the second item of the inner list.
+LaTeX&nbsp;allows you to nest lists deeper than
+you really should.</p>
+</div>
+</li>
+</ol>
+<p class=\\"ltx_p\\">This is the rest of the second item of the outer
 list. It is no more interesting than any other
-part of the item.
-                </p>
-                
-
-              </div>
-              
-
-            </li>
-            
-
-            <li
-              class="ltx_item"
-              id="S2.I2.i3"
-            >
-              
-
-              <div
-                class="ltx_para"
-                id="S2.I2.i3.p1"
-              >
-                
-
-                <p
-                  class="ltx_p"
-                >
-                  This is the third item of the list.
-                </p>
-                
-
-              </div>
-              
-
-            </li>
-            
-
-          </ul>
-          
-
-          <p
-            class="ltx_p"
-          >
-            You can even display poetry.
-          </p>
-          
-
-          <blockquote
-            class="ltx_quote ltx_role_verse"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              There is an environment
+part of the item.</p>
+</div>
+</li>
+<li id=\\"S2.I2.i3\\" class=\\"ltx_item\\">
+<div id=\\"S2.I2.i3.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is the third item of the list.</p>
+</div>
+</li>
+</ul>
+<p class=\\"ltx_p\\">You can even display poetry.</p>
+<blockquote class=\\"ltx_quote ltx_role_verse\\">
+<p class=\\"ltx_p\\">There is an environment
 for verse 
-
-              <br
-                class="ltx_break"
-              />
-              
+<br class=\\"ltx_break\\">
 Whose features some poets will curse.
 
+<br class=\\"ltx_break\\">
 
-              <br
-                class="ltx_break"
-              />
-              
-
-
-              <br
-                class="ltx_break"
-              />
-              
+<br class=\\"ltx_break\\">
 For instead of making
-
-              <br
-                class="ltx_break"
-              />
-              
-Them do 
-              <span
-                class="ltx_text ltx_emph ltx_font_italic"
-              >
-                all
-              </span>
-               line breaking, 
-
-              <br
-                class="ltx_break"
-              />
-              
+<br class=\\"ltx_break\\">
+Them do <span class=\\"ltx_text ltx_emph ltx_font_italic\\">all</span> line breaking, 
+<br class=\\"ltx_break\\">
 It allows them to put too many words on a line when they’d rather be
-forced to be terse.
-            </p>
-            
-
-          </blockquote>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S2.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Mathematical formulas may also be displayed. A
+forced to be terse.</p>
+</blockquote>
+</div>
+<div id=\\"S2.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Mathematical formulas may also be displayed. A
 displayed formula
 is
 one-line long; multiline
 formulas require special formatting instructions.
+</p>
+<table id=\\"S2.Ex1\\" class=\\"ltx_equation ltx_eqn_table\\">
 
-          </p>
-          
-
-          <table
-            class="ltx_equation ltx_eqn_table"
-            id="S2.Ex1"
-          >
-            
-
-
-            <tbody>
-              <tr
-                class="ltx_equation ltx_eqn_row ltx_align_baseline"
-              >
-                
-
-                <td
-                  class="ltx_eqn_cell ltx_eqn_center_padleft"
-                />
-                
-
-                <td
-                  class="ltx_eqn_cell ltx_align_center"
-                >
-                  <span
-                    class="ltx_DisplayMath"
-                    id="S2.Ex1.m1"
-                  >
-                    <span
-                      class="mjpage mjpage__block"
-                    >
-                      <span
-                        class="mjx-chtml MJXc-display"
-                        style="text-align: left;"
-                      >
-                        <span
-                          aria-label=" (\\\\Gamma,\\\\psi^{\\\\prime})=x^{\\\\prime\\\\prime}+y^{2}+z_{i}^{n} "
-                          class="mjx-math"
-                        >
-                          <span
-                            aria-hidden="true"
-                            class="mjx-mrow"
-                          >
-                            <span
-                              class="mjx-mo"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                              >
-                                (
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mi"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                              >
-                                Γ
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mo"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="margin-top: -0.144em; padding-bottom: 0.519em;"
-                              >
-                                ,
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-msubsup MJXc-space1"
-                            >
-                              <span
-                                class="mjx-base"
-                              >
-                                <span
-                                  class="mjx-mi"
-                                >
-                                  <span
-                                    class="mjx-char MJXc-TeX-math-I"
-                                    style="padding-top: 0.446em; padding-bottom: 0.519em;"
-                                  >
-                                    ψ
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-sup"
-                                style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;"
-                              >
-                                <span
-                                  class="mjx-texatom"
-                                  style=""
-                                >
-                                  <span
-                                    class="mjx-mrow"
-                                  >
-                                    <span
-                                      class="mjx-mi"
-                                    >
-                                      <span
-                                        class="mjx-char MJXc-TeX-main-R"
-                                        style="padding-top: 0.298em; padding-bottom: 0.298em;"
-                                      >
-                                        ′
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mo"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.446em; padding-bottom: 0.593em;"
-                              >
-                                )
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mo MJXc-space3"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.077em; padding-bottom: 0.298em;"
-                              >
-                                =
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-msubsup MJXc-space3"
-                            >
-                              <span
-                                class="mjx-base"
-                              >
-                                <span
-                                  class="mjx-mi"
-                                >
-                                  <span
-                                    class="mjx-char MJXc-TeX-math-I"
-                                    style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                  >
-                                    x
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-sup"
-                                style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;"
-                              >
-                                <span
-                                  class="mjx-texatom"
-                                  style=""
-                                >
-                                  <span
-                                    class="mjx-mrow"
-                                  >
-                                    <span
-                                      class="mjx-mi"
-                                    >
-                                      <span
-                                        class="mjx-char MJXc-TeX-main-R"
-                                        style="padding-top: 0.298em; padding-bottom: 0.298em;"
-                                      >
-                                        ′
-                                      </span>
-                                    </span>
-                                    <span
-                                      class="mjx-mi"
-                                    >
-                                      <span
-                                        class="mjx-char MJXc-TeX-main-R"
-                                        style="padding-top: 0.298em; padding-bottom: 0.298em;"
-                                      >
-                                        ′
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mo MJXc-space2"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                              >
-                                +
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-msubsup MJXc-space2"
-                            >
-                              <span
-                                class="mjx-base"
-                                style="margin-right: -0.006em;"
-                              >
-                                <span
-                                  class="mjx-mi"
-                                >
-                                  <span
-                                    class="mjx-char MJXc-TeX-math-I"
-                                    style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;"
-                                  >
-                                    y
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-sup"
-                                style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0.082em; padding-right: 0.071em;"
-                              >
-                                <span
-                                  class="mjx-texatom"
-                                  style=""
-                                >
-                                  <span
-                                    class="mjx-mrow"
-                                  >
-                                    <span
-                                      class="mjx-mn"
-                                    >
-                                      <span
-                                        class="mjx-char MJXc-TeX-main-R"
-                                        style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                                      >
-                                        2
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-mo MJXc-space2"
-                            >
-                              <span
-                                class="mjx-char MJXc-TeX-main-R"
-                                style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                              >
-                                +
-                              </span>
-                            </span>
-                            <span
-                              class="mjx-msubsup MJXc-space2"
-                            >
-                              <span
-                                class="mjx-base"
-                                style="margin-right: -0.003em;"
-                              >
-                                <span
-                                  class="mjx-mi"
-                                >
-                                  <span
-                                    class="mjx-char MJXc-TeX-math-I"
-                                    style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;"
-                                  >
-                                    z
-                                  </span>
-                                </span>
-                              </span>
-                              <span
-                                class="mjx-stack"
-                                style="vertical-align: -0.311em;"
-                              >
-                                <span
-                                  class="mjx-sup"
-                                  style="font-size: 70.7%; padding-bottom: 0.255em; padding-left: 0.076em; padding-right: 0.071em;"
-                                >
-                                  <span
-                                    class="mjx-texatom"
-                                    style=""
-                                  >
-                                    <span
-                                      class="mjx-mrow"
-                                    >
-                                      <span
-                                        class="mjx-mi"
-                                      >
-                                        <span
-                                          class="mjx-char MJXc-TeX-math-I"
-                                          style="padding-top: 0.225em; padding-bottom: 0.298em;"
-                                        >
-                                          n
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                                <span
-                                  class="mjx-sub"
-                                  style="font-size: 70.7%; padding-right: 0.071em;"
-                                >
-                                  <span
-                                    class="mjx-texatom"
-                                    style=""
-                                  >
-                                    <span
-                                      class="mjx-mrow"
-                                    >
-                                      <span
-                                        class="mjx-mi"
-                                      >
-                                        <span
-                                          class="mjx-char MJXc-TeX-math-I"
-                                          style="padding-top: 0.446em; padding-bottom: 0.298em;"
-                                        >
-                                          i
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </td>
-                
-
-                <td
-                  class="ltx_eqn_cell ltx_eqn_center_padright"
-                />
-                
-
-              </tr>
-              
-
-            </tbody>
-          </table>
-          
-
-          <p
-            class="ltx_p"
-          >
-            Don’t start a paragraph with a displayed equation,
-nor make one a paragraph by itself.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+<tbody><tr class=\\"ltx_equation ltx_eqn_row ltx_align_baseline\\">
+<td class=\\"ltx_eqn_cell ltx_eqn_center_padleft\\"></td>
+<td class=\\"ltx_eqn_cell ltx_align_center\\"><span id=\\"S2.Ex1.m1\\" class=\\"ltx_DisplayMath\\"><span class=\\"mjpage mjpage__block\\"><span class=\\"mjx-chtml MJXc-display\\" style=\\"text-align: left;\\"><span class=\\"mjx-math\\" aria-label=\\" (\\\\Gamma,\\\\psi^{\\\\prime})=x^{\\\\prime\\\\prime}+y^{2}+z_{i}^{n} \\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">(</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">Γ</span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"margin-top: -0.144em; padding-bottom: 0.519em;\\">,</span></span><span class=\\"mjx-msubsup MJXc-space1\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.519em;\\">ψ</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.298em;\\">′</span></span></span></span></span></span><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.446em; padding-bottom: 0.593em;\\">)</span></span><span class=\\"mjx-mo MJXc-space3\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.077em; padding-bottom: 0.298em;\\">=</span></span><span class=\\"mjx-msubsup MJXc-space3\\"><span class=\\"mjx-base\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">x</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.298em;\\">′</span></span><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.298em;\\">′</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">+</span></span><span class=\\"mjx-msubsup MJXc-space2\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.006em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;\\">y</span></span></span><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; vertical-align: 0.584em; padding-left: 0.082em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">2</span></span></span></span></span></span><span class=\\"mjx-mo MJXc-space2\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">+</span></span><span class=\\"mjx-msubsup MJXc-space2\\"><span class=\\"mjx-base\\" style=\\"margin-right: -0.003em;\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;\\">z</span></span></span><span class=\\"mjx-stack\\" style=\\"vertical-align: -0.311em;\\"><span class=\\"mjx-sup\\" style=\\"font-size: 70.7%; padding-bottom: 0.255em; padding-left: 0.076em; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.225em; padding-bottom: 0.298em;\\">n</span></span></span></span></span><span class=\\"mjx-sub\\" style=\\"font-size: 70.7%; padding-right: 0.071em;\\"><span class=\\"mjx-texatom\\" style=\\"\\"><span class=\\"mjx-mrow\\"><span class=\\"mjx-mi\\"><span class=\\"mjx-char MJXc-TeX-math-I\\" style=\\"padding-top: 0.446em; padding-bottom: 0.298em;\\">i</span></span></span></span></span></span></span></span></span></span></span></span></td>
+<td class=\\"ltx_eqn_cell ltx_eqn_center_padright\\"></td>
+</tr>
+</tbody></table>
+<p class=\\"ltx_p\\">Don’t start a paragraph with a displayed equation,
+nor make one a paragraph by itself.</p>
 </div>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`small2e.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Simple Text</h2>
 
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Simple Text
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Words are separated by one or more spaces. Paragraphs are separated by
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Words are separated by one or more spaces. Paragraphs are separated by
 one or more blank lines. The output is not affected by adding extra
-spaces or extra blank lines to the input file.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Double quotes are typed like this: “quoted text”.
-Single quotes are typed like this: ‘single-quoted text’.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p3"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Long dashes are typed as three dash characters—like this.
-
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S1.p4"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Emphasized text is typed like this: 
-            <span
-              class="ltx_text ltx_emph ltx_font_italic"
-            >
-              this is emphasized
-            </span>
-            .
-Bold text is typed like this: 
-            <span
-              class="ltx_text ltx_font_bold"
-            >
-              this is bold
-            </span>
-            .
-          </p>
-          
-
-        </div>
-        
-
-        <section
-          class="ltx_subsection"
-          id="S1.SS1"
-        >
-          
-
-          <h3
-            class="ltx_title ltx_title_subsection"
-          >
-            
-
-            <span
-              class="ltx_tag ltx_tag_subsection"
-            >
-              1.1 
-            </span>
-            A Warning or Two
-          </h3>
-          
-
-
-          <div
-            class="ltx_para"
-            id="S1.SS1.p1"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              If you get too much space after a mid-sentence period—abbreviations
-like etc. are the common culprits)—then type a backslash followed by
-a space after the period, as in this sentence.
-            </p>
-            
-
-          </div>
-          
-
-          <div
-            class="ltx_para"
-            id="S1.SS1.p2"
-          >
-            
-
-            <p
-              class="ltx_p"
-            >
-              Remember, don’t type the 10 special characters (such as dollar sign and
-backslash) except as directed! The following seven are printed by
-typing a backslash in front of them: $ & # % _ { and }.
-The manual tells how to make other symbols.
-            </p>
-            
-
-          </div>
-          
-
-        </section>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+spaces or extra blank lines to the input file.</p>
 </div>
+<div id=\\"S1.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Double quotes are typed like this: “quoted text”.
+Single quotes are typed like this: ‘single-quoted text’.</p>
+</div>
+<div id=\\"S1.p3\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Long dashes are typed as three dash characters—like this.
+</p>
+</div>
+<div id=\\"S1.p4\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Emphasized text is typed like this: <span class=\\"ltx_text ltx_emph ltx_font_italic\\">this is emphasized</span>.
+Bold text is typed like this: <span class=\\"ltx_text ltx_font_bold\\">this is bold</span>.</p>
+</div>
+<section id=\\"S1.SS1\\" class=\\"ltx_subsection\\">
+<h3 class=\\"ltx_title ltx_title_subsection\\">
+<span class=\\"ltx_tag ltx_tag_subsection\\">1.1 </span>A Warning or Two</h3>
+
+<div id=\\"S1.SS1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">If you get too much space after a mid-sentence period—abbreviations
+like etc.&nbsp;are the common culprits)—then type a backslash followed by
+a space after the period, as in this sentence.</p>
+</div>
+<div id=\\"S1.SS1.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Remember, don’t type the 10 special characters (such as dollar sign and
+backslash) except as directed! The following seven are printed by
+typing a backslash in front of them: $ &amp; # % _ { and }.
+The manual tells how to make other symbols.</p>
+</div>
+</section>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`tables.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Basic
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_align_middle"
-          >
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  3
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  4
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  6
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  7
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  9
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S2"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            2 
-          </span>
-          Vertical lines
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S2.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_align_middle"
-          >
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  3
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  4
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r"
-                >
-                  5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  6
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  7
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r"
-                >
-                  8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  9
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S3"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            3 
-          </span>
-          Horizontal lines at top and bottom
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S3.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_align_middle"
-          >
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right ltx_border_t"
-                >
-                  3
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  4
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r"
-                >
-                  5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  6
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r"
-                >
-                  7
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r"
-                >
-                  8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right ltx_border_b"
-                >
-                  9
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S4"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            4 
-          </span>
-          Lines between every row
-        </h2>
-        
-
-
-        <div
-          class="ltx_para ltx_align_center"
-          id="S4.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t"
-                >
-                  1
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_r ltx_border_t"
-                >
-                  2
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_column ltx_border_t"
-                >
-                  3
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  4
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right ltx_border_t"
-                >
-                  6
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  7
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right ltx_border_b ltx_border_t"
-                >
-                  9
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S4.p2"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_column ltx_th_row ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  7C0
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t"
-                >
-                  hexadecimal
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_l ltx_border_r"
-                >
-                  3700
-                </th>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  octal
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_l ltx_border_r"
-                >
-                  11111000000
-                </th>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  binary
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_b ltx_border_l ltx_border_r ltx_border_tt"
-                >
-                  1984
-                </th>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_tt"
-                >
-                  decimal
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S5"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            5 
-          </span>
-          Text column with width
-        </h2>
-        
-
-
-        <div
-          class="ltx_para ltx_align_center"
-          id="S5.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  Day
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t"
-                >
-                  Min Temp
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t"
-                >
-                  Max Temp
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_justify ltx_th ltx_th_column ltx_border_r ltx_border_t"
-                  style="width:142.3pt;"
-                >
-                  Summary
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  Monday
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  11C
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  22C
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_r ltx_border_t"
-                  style="width:142.3pt;"
-                >
-                  A clear day with lots of sunshine.
-However, the strong breeze will bring down the temperatures.
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  Tuesday
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  9C
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  19C
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_r ltx_border_t"
-                  style="width:142.3pt;"
-                >
-                  Cloudy with rain, across many northern regions. Clear spells
-across most of Scotland and Northern Ireland,
-but rain reaching the far northwest.
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  Wednesday
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  10C
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  21C
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t"
-                  style="width:142.3pt;"
-                >
-                  Rain will still linger for the morning.
-Conditions will improve by early afternoon and continue
-throughout the evening.
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S6"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            6 
-          </span>
-          Defining multiple columns
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S6.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_left ltx_th ltx_th_column"
-                >
-                  Team
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  P
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  W
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  D
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  L
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  F
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  A
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_column"
-                >
-                  Pts
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_t"
-                >
-                  Manchester United
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_t"
-                >
-                  6
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_t"
-                >
-                  4
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_t"
-                >
-                  0
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_t"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_t"
-                >
-                  10
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_t"
-                >
-                  5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right ltx_border_t"
-                >
-                  12
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  Celtic
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  6
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  0
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  9
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  9
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  Benfica
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  6
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  7
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  7
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  FC Copenhagen
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  6
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right"
-                >
-                  7
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S7"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            7 
-          </span>
-          Rows spanning multiple columns
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S7.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_l ltx_border_r ltx_border_t"
-                  colspan="2"
-                >
-                  Team sheet
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  GK
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  Paul Robinson
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  LB
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Lucas Radebe
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  DC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Michael Duberry
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  DC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Dominic Matteo
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  RB
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Dider Domi
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  MC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  David Batty
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  MC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Eirik Bakke
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  MC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Jody Morris
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  FW
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Jamie McMaster
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r"
-                >
-                  ST
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Alan Smith
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_l ltx_border_r"
-                >
-                  ST
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r"
-                >
-                  Mark Viduka
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S8"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            8 
-          </span>
-          Columns spanning multiple rows
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S8.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_l ltx_border_r ltx_border_t"
-                  colspan="3"
-                >
-                  Team sheet
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  Goalkeeper
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  GK
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  Paul Robinson
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t"
-                  rowspan="4"
-                >
-                  Defenders
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  LB
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  Lucas Radebe
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  DC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Michael Duburry
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  DC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Dominic Matteo
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  RB
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Didier Domi
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t"
-                  rowspan="3"
-                >
-                  Midfielders
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  MC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  David Batty
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  MC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Eirik Bakke
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  MC
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r"
-                >
-                  Jody Morris
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  Forward
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  FW
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  Jamie McMaster
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_l ltx_border_r ltx_border_t"
-                  rowspan="2"
-                >
-                  Strikers
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  ST
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_r ltx_border_t"
-                >
-                  Alan Smith
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r"
-                >
-                  ST
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left ltx_border_b ltx_border_r"
-                >
-                  Mark Viduka
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S8.p2"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_th ltx_th_column"
-                />
-                
-
-                <th
-                  class="ltx_td ltx_th ltx_th_column ltx_border_r"
-                />
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_r ltx_border_t"
-                  colspan="4"
-                >
-                  Primes
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_th ltx_th_column"
-                />
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td"
-                />
-                
-
-                <td
-                  class="ltx_td ltx_border_r"
-                />
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  7
-                </td>
-                
-
-                <td
-                  class="ltx_td"
-                />
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_l ltx_border_t"
-                  rowspan="2"
-                >
-                  Powers
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  504
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  0
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td"
-                />
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  540
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  0
-                </td>
-                
-
-                <td
-                  class="ltx_td"
-                />
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_l ltx_border_t"
-                  rowspan="2"
-                >
-                  Powers
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  gcd
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  0
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  0
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  min
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  lcm
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_left"
-                >
-                  max
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S8.p3"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_th ltx_th_column ltx_th_row"
-                />
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  noninteractive
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_align_center ltx_th ltx_th_column"
-                >
-                  interactive
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_r"
-                >
-                  massively multiple
-                </th>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  Library
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  University
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_r"
-                >
-                  one-to-one
-                </th>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  Book
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  Tutor
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S9"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            9 
-          </span>
-          Table with width
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S9.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_align_middle"
-            style="width:325.2pt;"
-          >
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  label 1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  label 2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_r ltx_border_t"
-                >
-                  label 3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right ltx_border_r ltx_border_t"
-                >
-                  label 4
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  item 1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  item 2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  item 3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_right ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  item 4
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S10"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            10 
-          </span>
-          tabularx
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S10.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_align_middle"
-            style="width:433.6pt;"
-          >
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  label 1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_r ltx_border_t"
-                >
-                  label 2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_r ltx_border_t"
-                >
-                  label 3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_r ltx_border_t"
-                >
-                  label 4
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_b ltx_border_l ltx_border_r ltx_border_t"
-                >
-                  item 1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  item 2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  item 3
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t"
-                >
-                  item 4
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S11"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            11 
-          </span>
-          tabulary
-        </h2>
-        
-
-
-        <div
-          class="ltx_para ltx_align_center"
-          id="S11.p1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_guessed_headers ltx_align_middle"
-            style="width:303.5pt;"
-          >
-            
-
-            <thead
-              class="ltx_thead"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <th
-                  class="ltx_td ltx_wrap ltx_align_left ltx_th ltx_th_column"
-                >
-                  Short sentences
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_wrap ltx_align_center ltx_th ltx_th_column"
-                >
-                  #
-                </th>
-                
-
-                <th
-                  class="ltx_td ltx_wrap ltx_align_left ltx_th ltx_th_column"
-                >
-                  Long sentences
-                </th>
-                
-
-              </tr>
-              
-
-            </thead>
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_wrap ltx_align_left ltx_border_t"
-                >
-                  This is short.
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_wrap ltx_align_center ltx_border_t"
-                >
-                  173
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_wrap ltx_align_left ltx_border_t"
-                >
-                  This is much loooooooonger, because there are many more words.
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_wrap ltx_align_left"
-                >
-                  This is not shorter.
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_wrap ltx_align_center"
-                >
-                  317
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_wrap ltx_align_left"
-                >
-                  This is still loooooooonger, because there are many more words.
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S12"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            12 
-          </span>
-          Captions and references
-        </h2>
-        
-
-
-        <figure
-          class="ltx_table"
-          id="S12.T1"
-        >
-          
-
-          <table
-            class="ltx_tabular ltx_align_middle"
-          >
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell1
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell2
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell3
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell4
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell5
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell6
-                </td>
-                
-
-              </tr>
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell7
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell9
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-          <figcaption
-            class="ltx_caption"
-          >
-            <span
-              class="ltx_tag ltx_tag_table"
-            >
-              Table 1: 
-            </span>
-            Some numbers.
-          </figcaption>
-          
-
-        </figure>
-        
-
-        <div
-          class="ltx_para"
-          id="S12.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Take a look at some cool data in table 
-            <a
-              class="ltx_ref"
-              href="#S12.T1"
-              title="Table 1 ‣ 12 Captions and references"
-            >
-              <span
-                class="ltx_text ltx_ref_tag"
-              >
-                1
-              </span>
-            </a>
-            .
-          </p>
-          
-
-        </div>
-        
-
-        <figure
-          class="ltx_table"
-          id="S12.T2"
-        >
-          
-
-
-          <table
-            class="ltx_tabular ltx_align_middle"
-          >
-            
-
-            <tbody
-              class="ltx_tbody"
-            >
-              
-
-              <tr
-                class="ltx_tr"
-              >
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell7
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell8
-                </td>
-                
-
-                <td
-                  class="ltx_td ltx_align_center"
-                >
-                  cell9
-                </td>
-                
-
-              </tr>
-              
-
-            </tbody>
-            
-
-          </table>
-          
-
-          <figcaption
-            class="ltx_caption"
-          >
-            <span
-              class="ltx_tag ltx_tag_table"
-            >
-              Table 2: 
-            </span>
-            Caption at the top is put at the bottom.
-          </figcaption>
-        </figure>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Basic</h2>
+
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_align_middle\\">
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left\\">1</td>
+<td class=\\"ltx_td ltx_align_center\\">2</td>
+<td class=\\"ltx_td ltx_align_right\\">3</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left\\">4</td>
+<td class=\\"ltx_td ltx_align_center\\">5</td>
+<td class=\\"ltx_td ltx_align_right\\">6</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left\\">7</td>
+<td class=\\"ltx_td ltx_align_center\\">8</td>
+<td class=\\"ltx_td ltx_align_right\\">9</td>
+</tr>
+</tbody>
+</table>
 </div>
+</section>
+<section id=\\"S2\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">2 </span>Vertical lines</h2>
+
+<div id=\\"S2.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_align_middle\\">
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">1</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r\\">2</td>
+<td class=\\"ltx_td ltx_align_right\\">3</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">4</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r\\">5</td>
+<td class=\\"ltx_td ltx_align_right\\">6</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">7</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r\\">8</td>
+<td class=\\"ltx_td ltx_align_right\\">9</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S3\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">3 </span>Horizontal lines at top and bottom</h2>
+
+<div id=\\"S3.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_align_middle\\">
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">1</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">2</td>
+<td class=\\"ltx_td ltx_align_right ltx_border_t\\">3</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">4</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r\\">5</td>
+<td class=\\"ltx_td ltx_align_right\\">6</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r\\">7</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r\\">8</td>
+<td class=\\"ltx_td ltx_align_right ltx_border_b\\">9</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S4\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">4 </span>Lines between every row</h2>
+
+<div id=\\"S4.p1\\" class=\\"ltx_para ltx_align_center\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t\\">1</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_r ltx_border_t\\">2</th>
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_column ltx_border_t\\">3</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">4</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">5</td>
+<td class=\\"ltx_td ltx_align_right ltx_border_t\\">6</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_t\\">7</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">8</td>
+<td class=\\"ltx_td ltx_align_right ltx_border_b ltx_border_t\\">9</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div id=\\"S4.p2\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_column ltx_th_row ltx_border_l ltx_border_r ltx_border_t\\">7C0</th>
+<th class=\\"ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t\\">hexadecimal</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_l ltx_border_r\\">3700</th>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">octal</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_l ltx_border_r\\">11111000000</th>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">binary</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_b ltx_border_l ltx_border_r ltx_border_tt\\">1984</th>
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_tt\\">decimal</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S5\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">5 </span>Text column with width</h2>
+
+<div id=\\"S5.p1\\" class=\\"ltx_para ltx_align_center\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_l ltx_border_r ltx_border_t\\">Day</th>
+<th class=\\"ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t\\">Min Temp</th>
+<th class=\\"ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t\\">Max Temp</th>
+<th class=\\"ltx_td ltx_align_justify ltx_th ltx_th_column ltx_border_r ltx_border_t\\" style=\\"width:142.3pt;\\">Summary</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t\\">Monday</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">11C</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">22C</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_r ltx_border_t\\" style=\\"width:142.3pt;\\">A clear day with lots of sunshine.
+However, the strong breeze will bring down the temperatures.</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t\\">Tuesday</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">9C</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">19C</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_r ltx_border_t\\" style=\\"width:142.3pt;\\">Cloudy with rain, across many northern regions. Clear spells
+across most of Scotland and Northern Ireland,
+but rain reaching the far northwest.</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_l ltx_border_r ltx_border_t\\">Wednesday</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_t\\">10C</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r ltx_border_t\\">21C</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t\\" style=\\"width:142.3pt;\\">Rain will still linger for the morning.
+Conditions will improve by early afternoon and continue
+throughout the evening.</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S6\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">6 </span>Defining multiple columns</h2>
+
+<div id=\\"S6.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_left ltx_th ltx_th_column\\">Team</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">P</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">W</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">D</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">L</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">F</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">A</th>
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_column\\">Pts</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_t\\">Manchester United</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_t\\">6</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_t\\">4</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_t\\">0</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_t\\">2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_t\\">10</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_t\\">5</td>
+<td class=\\"ltx_td ltx_align_right ltx_border_t\\">12</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left\\">Celtic</td>
+<td class=\\"ltx_td ltx_align_center\\">6</td>
+<td class=\\"ltx_td ltx_align_center\\">3</td>
+<td class=\\"ltx_td ltx_align_center\\">0</td>
+<td class=\\"ltx_td ltx_align_center\\">3</td>
+<td class=\\"ltx_td ltx_align_center\\">8</td>
+<td class=\\"ltx_td ltx_align_center\\">9</td>
+<td class=\\"ltx_td ltx_align_right\\">9</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left\\">Benfica</td>
+<td class=\\"ltx_td ltx_align_center\\">6</td>
+<td class=\\"ltx_td ltx_align_center\\">2</td>
+<td class=\\"ltx_td ltx_align_center\\">1</td>
+<td class=\\"ltx_td ltx_align_center\\">3</td>
+<td class=\\"ltx_td ltx_align_center\\">7</td>
+<td class=\\"ltx_td ltx_align_center\\">8</td>
+<td class=\\"ltx_td ltx_align_right\\">7</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left\\">FC Copenhagen</td>
+<td class=\\"ltx_td ltx_align_center\\">6</td>
+<td class=\\"ltx_td ltx_align_center\\">2</td>
+<td class=\\"ltx_td ltx_align_center\\">1</td>
+<td class=\\"ltx_td ltx_align_center\\">3</td>
+<td class=\\"ltx_td ltx_align_center\\">5</td>
+<td class=\\"ltx_td ltx_align_center\\">8</td>
+<td class=\\"ltx_td ltx_align_right\\">7</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S7\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">7 </span>Rows spanning multiple columns</h2>
+
+<div id=\\"S7.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_l ltx_border_r ltx_border_t\\" colspan=\\"2\\">Team sheet</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t\\">GK</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">Paul Robinson</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">LB</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Lucas Radebe</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">DC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Michael Duberry</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">DC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Dominic Matteo</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">RB</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Dider Domi</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">MC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">David Batty</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">MC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Eirik Bakke</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">MC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Jody Morris</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">FW</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Jamie McMaster</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r\\">ST</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Alan Smith</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_l ltx_border_r\\">ST</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r\\">Mark Viduka</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S8\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">8 </span>Columns spanning multiple rows</h2>
+
+<div id=\\"S8.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_l ltx_border_r ltx_border_t\\" colspan=\\"3\\">Team sheet</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t\\">Goalkeeper</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">GK</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">Paul Robinson</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t\\" rowspan=\\"4\\">Defenders</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">LB</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">Lucas Radebe</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">DC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Michael Duburry</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">DC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Dominic Matteo</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">RB</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Didier Domi</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t\\" rowspan=\\"3\\">Midfielders</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">MC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">David Batty</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">MC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Eirik Bakke</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">MC</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r\\">Jody Morris</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_l ltx_border_r ltx_border_t\\">Forward</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">FW</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">Jamie McMaster</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_l ltx_border_r ltx_border_t\\" rowspan=\\"2\\">Strikers</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">ST</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_r ltx_border_t\\">Alan Smith</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r\\">ST</td>
+<td class=\\"ltx_td ltx_align_left ltx_border_b ltx_border_r\\">Mark Viduka</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div id=\\"S8.p2\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_th ltx_th_column\\"></th>
+<th class=\\"ltx_td ltx_th ltx_th_column ltx_border_r\\"></th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column ltx_border_r ltx_border_t\\" colspan=\\"4\\">Primes</th>
+<th class=\\"ltx_td ltx_th ltx_th_column\\"></th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td\\"></td>
+<td class=\\"ltx_td ltx_border_r\\"></td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">3</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">5</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">7</td>
+<td class=\\"ltx_td\\"></td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center ltx_border_l ltx_border_t\\" rowspan=\\"2\\">Powers</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t\\">504</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">3</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">0</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">1</td>
+<td class=\\"ltx_td\\"></td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t\\">540</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">3</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">1</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">0</td>
+<td class=\\"ltx_td\\"></td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_l ltx_border_t\\" rowspan=\\"2\\">Powers</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t\\">gcd</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">0</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">0</td>
+<td class=\\"ltx_td ltx_align_left\\">min</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_l ltx_border_r ltx_border_t\\">lcm</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">3</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">3</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">1</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">1</td>
+<td class=\\"ltx_td ltx_align_left\\">max</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div id=\\"S8.p3\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_th ltx_th_column ltx_th_row\\"></th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">noninteractive</th>
+<th class=\\"ltx_td ltx_align_center ltx_th ltx_th_column\\">interactive</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_r\\">massively multiple</th>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">Library</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">University</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_align_right ltx_th ltx_th_row ltx_border_r\\">one-to-one</th>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">Book</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">Tutor</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S9\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">9 </span>Table with width</h2>
+
+<div id=\\"S9.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_align_middle\\" style=\\"width:325.2pt;\\">
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center ltx_border_l ltx_border_r ltx_border_t\\">label 1</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">label 2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_r ltx_border_t\\">label 3</td>
+<td class=\\"ltx_td ltx_align_right ltx_border_r ltx_border_t\\">label 4</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_l ltx_border_r ltx_border_t\\">item 1</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">item 2</td>
+<td class=\\"ltx_td ltx_align_center ltx_border_b ltx_border_r ltx_border_t\\">item 3</td>
+<td class=\\"ltx_td ltx_align_right ltx_border_b ltx_border_r ltx_border_t\\">item 4</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S10\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">10 </span>tabularx</h2>
+
+<div id=\\"S10.p1\\" class=\\"ltx_para\\">
+<table class=\\"ltx_tabular ltx_align_middle\\" style=\\"width:433.6pt;\\">
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_justify ltx_border_l ltx_border_r ltx_border_t\\">label 1</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_r ltx_border_t\\">label 2</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_r ltx_border_t\\">label 3</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_r ltx_border_t\\">label 4</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_justify ltx_border_b ltx_border_l ltx_border_r ltx_border_t\\">item 1</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t\\">item 2</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t\\">item 3</td>
+<td class=\\"ltx_td ltx_align_justify ltx_border_b ltx_border_r ltx_border_t\\">item 4</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S11\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">11 </span>tabulary</h2>
+
+<div id=\\"S11.p1\\" class=\\"ltx_para ltx_align_center\\">
+<table class=\\"ltx_tabular ltx_guessed_headers ltx_align_middle\\" style=\\"width:303.5pt;\\">
+<thead class=\\"ltx_thead\\">
+<tr class=\\"ltx_tr\\">
+<th class=\\"ltx_td ltx_wrap ltx_align_left ltx_th ltx_th_column\\">Short sentences</th>
+<th class=\\"ltx_td ltx_wrap ltx_align_center ltx_th ltx_th_column\\">#</th>
+<th class=\\"ltx_td ltx_wrap ltx_align_left ltx_th ltx_th_column\\">Long sentences</th>
+</tr>
+</thead>
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_wrap ltx_align_left ltx_border_t\\">This is short.</td>
+<td class=\\"ltx_td ltx_wrap ltx_align_center ltx_border_t\\">173</td>
+<td class=\\"ltx_td ltx_wrap ltx_align_left ltx_border_t\\">This is much loooooooonger, because there are many more words.</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_wrap ltx_align_left\\">This is not shorter.</td>
+<td class=\\"ltx_td ltx_wrap ltx_align_center\\">317</td>
+<td class=\\"ltx_td ltx_wrap ltx_align_left\\">This is still loooooooonger, because there are many more words.</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+<section id=\\"S12\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">12 </span>Captions and references</h2>
+
+<figure id=\\"S12.T1\\" class=\\"ltx_table\\">
+<table class=\\"ltx_tabular ltx_align_middle\\">
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center\\">cell1</td>
+<td class=\\"ltx_td ltx_align_center\\">cell2</td>
+<td class=\\"ltx_td ltx_align_center\\">cell3</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center\\">cell4</td>
+<td class=\\"ltx_td ltx_align_center\\">cell5</td>
+<td class=\\"ltx_td ltx_align_center\\">cell6</td>
+</tr>
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center\\">cell7</td>
+<td class=\\"ltx_td ltx_align_center\\">cell8</td>
+<td class=\\"ltx_td ltx_align_center\\">cell9</td>
+</tr>
+</tbody>
+</table>
+<figcaption class=\\"ltx_caption\\"><span class=\\"ltx_tag ltx_tag_table\\">Table 1: </span>Some numbers.</figcaption>
+</figure>
+<div id=\\"S12.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Take a look at some cool data in table <a href=\\"#S12.T1\\" title=\\"Table 1 ‣ 12 Captions and references\\" class=\\"ltx_ref\\"><span class=\\"ltx_text ltx_ref_tag\\">1</span></a>.</p>
+</div>
+<figure id=\\"S12.T2\\" class=\\"ltx_table\\">
+
+<table class=\\"ltx_tabular ltx_align_middle\\">
+<tbody class=\\"ltx_tbody\\">
+<tr class=\\"ltx_tr\\">
+<td class=\\"ltx_td ltx_align_center\\">cell7</td>
+<td class=\\"ltx_td ltx_align_center\\">cell8</td>
+<td class=\\"ltx_td ltx_align_center\\">cell9</td>
+</tr>
+</tbody>
+</table>
+<figcaption class=\\"ltx_caption\\"><span class=\\"ltx_tag ltx_tag_table\\">Table 2: </span>Caption at the top is put at the bottom.</figcaption></figure>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`text.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <section
-        class="ltx_section"
-        id="S1"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            1 
-          </span>
-          Fonts
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S1.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            This is 
-            <span
-              class="ltx_text ltx_emph ltx_font_italic"
-            >
-              emph
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            This is textrm 
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_text ltx_font_sansserif"
-            >
-              textsf
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_text ltx_font_smallcaps"
-            >
-              Small Caps
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            This is UPPERCASE 
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_text ltx_font_italic"
-            >
-              textit
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_text ltx_font_typewriter"
-            >
-              fixed width
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_text ltx_font_bold"
-            >
-              textbf
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            This is textmd 
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_ERROR undefined"
-            >
-              \\textlf
-            </span>
-            textlf 
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_text ltx_framed_underline"
-            >
-              underline
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S2"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            2 
-          </span>
-          ulem package
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S2.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            This is 
-            <span
-              class="ltx_text ltx_ulem_uline"
-            >
-              uline
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            This is 
-            <span
-              class="ltx_text ltx_ulem_sout"
-            >
-              sout
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S3"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            3 
-          </span>
-          Sizing
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S3.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            <span
-              class="ltx_text"
-              style="font-size:50%;"
-            >
-              tiny
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:70%;"
-            >
-              scriptsize
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:80%;"
-            >
-              footnotesize
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:90%;"
-            >
-              small
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            normalsize 
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:120%;"
-            >
-              large
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:144%;"
-            >
-              Large
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:173%;"
-            >
-              LARGE
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:207%;"
-            >
-              huge
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-            <span
-              class="ltx_text"
-              style="font-size:298%;"
-            >
-              Huge
-            </span>
-             
-
-            <br
-              class="ltx_break"
-            />
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S4"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            4 
-          </span>
-          Colors
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S4.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            black text 
-            <span
-              class="ltx_text"
-              style="color:#FF0000;"
-            >
-              red text
-            </span>
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S4.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            <span
-              class="ltx_text"
-              style="color:#FFFFFF;background-color:#FF0000;"
-            >
-              white text on red background
-            </span>
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S5"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            5 
-          </span>
-          Spacing
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S5.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            The last two words have a non-breaking space.
-          </p>
-          
-
-        </div>
-        
-
-        <div
-          class="ltx_para"
-          id="S5.p2"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Before hfill.  After hfill.
-
-          </p>
-          
-
-        </div>
-        
-
-        <span
-          class="ltx_ERROR undefined"
-        >
-          {doublespace}
-        </span>
-        
-
-        <div
-          class="ltx_para"
-          id="S5.p3"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            This paragraph has 
-
-            <br
-              class="ltx_break"
-            />
-            double 
-
-            <br
-              class="ltx_break"
-            />
-            line spacing.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S6"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            6 
-          </span>
-          Quotes
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S6.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            To ‘quote’ in LaTeX 
-
-            <br
-              class="ltx_break"
-            />
-            To “quote” in LaTeX 
-
-            <br
-              class="ltx_break"
-            />
-            To “quote” in LaTeX 
-
-            <br
-              class="ltx_break"
-            />
-            To ,,quote” in LaTeX 
-
-            <br
-              class="ltx_break"
-            />
-            ,,German quotation marks“ 
-
-            <br
-              class="ltx_break"
-            />
-            ¡¡French quotation marks¿¿ 
-
-            <br
-              class="ltx_break"
-            />
-            “Please press the ‘x’ key.” 
-
-            <br
-              class="ltx_break"
-            />
-            ,,ProszÄ, naciÅnij klawisz ¡¡x¿¿”.
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S7"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            7 
-          </span>
-          Super/subscript
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S7.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Some
-            <sup
-              class="ltx_sup"
-            >
-              superscript
-            </sup>
-             
-
-            <br
-              class="ltx_break"
-            />
-            Some
-            <span
-              class="ltx_ERROR undefined"
-            >
-              \\textsubscript
-            </span>
-            subscript
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S8"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            8 
-          </span>
-          Dashes and hypens
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S8.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Hyphen: daughter-in-law, X-rated
-
-            <br
-              class="ltx_break"
-            />
-            En dash: pages 13–67
-
-            <br
-              class="ltx_break"
-            />
-            Em dash: yes—or no? 
-
-            <br
-              class="ltx_break"
-            />
-            Minus sign: 
-            <span
-              class="ltx_Math"
-              id="S8.p1.m1"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="0"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mn"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                        >
-                          0
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-            , 
-            <span
-              class="ltx_Math"
-              id="S8.p1.m2"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="1"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mn"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                        >
-                          1
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-             and 
-            <span
-              class="ltx_Math"
-              id="S8.p1.m3"
-            >
-              <span
-                class="mjpage"
-              >
-                <span
-                  class="mjx-chtml"
-                >
-                  <span
-                    aria-label="-1"
-                    class="mjx-math"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="mjx-mrow"
-                    >
-                      <span
-                        class="mjx-mo"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.298em; padding-bottom: 0.446em;"
-                        >
-                          −
-                        </span>
-                      </span>
-                      <span
-                        class="mjx-mn"
-                      >
-                        <span
-                          class="mjx-char MJXc-TeX-main-R"
-                          style="padding-top: 0.372em; padding-bottom: 0.372em;"
-                        >
-                          1
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </span>
-            </span>
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-      <section
-        class="ltx_section"
-        id="S9"
-      >
-        
-
-        <h2
-          class="ltx_title ltx_title_section"
-        >
-          
-
-          <span
-            class="ltx_tag ltx_tag_section"
-          >
-            9 
-          </span>
-          Ellipsis
-        </h2>
-        
-
-
-        <div
-          class="ltx_para"
-          id="S9.p1"
-        >
-          
-
-          <p
-            class="ltx_p"
-          >
-            Not like this … but like this:
-
-            <br
-              class="ltx_break"
-            />
-            New York, Tokyo, Budapest, …
-          </p>
-          
-
-        </div>
-        
-
-      </section>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<section id=\\"S1\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">1 </span>Fonts</h2>
+
+<div id=\\"S1.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is <span class=\\"ltx_text ltx_emph ltx_font_italic\\">emph</span> 
+<br class=\\"ltx_break\\">This is textrm 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_text ltx_font_sansserif\\">textsf</span> 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_text ltx_font_smallcaps\\">Small Caps</span> 
+<br class=\\"ltx_break\\">This is UPPERCASE 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_text ltx_font_italic\\">textit</span> 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_text ltx_font_typewriter\\">fixed width</span> 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_text ltx_font_bold\\">textbf</span> 
+<br class=\\"ltx_break\\">This is textmd 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_ERROR undefined\\">\\\\textlf</span>textlf 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_text ltx_framed_underline\\">underline</span> 
+<br class=\\"ltx_break\\"></p>
 </div>
+</section>
+<section id=\\"S2\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">2 </span>ulem package</h2>
+
+<div id=\\"S2.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This is <span class=\\"ltx_text ltx_ulem_uline\\">uline</span> 
+<br class=\\"ltx_break\\">This is <span class=\\"ltx_text ltx_ulem_sout\\">sout</span> 
+<br class=\\"ltx_break\\"></p>
+</div>
+</section>
+<section id=\\"S3\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">3 </span>Sizing</h2>
+
+<div id=\\"S3.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\"><span class=\\"ltx_text\\" style=\\"font-size:50%;\\">tiny</span> 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:70%;\\">scriptsize</span> 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:80%;\\">footnotesize</span> 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:90%;\\">small</span> 
+<br class=\\"ltx_break\\">normalsize 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:120%;\\">large</span> 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:144%;\\">Large</span> 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:173%;\\">LARGE</span> 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:207%;\\">huge</span> 
+<br class=\\"ltx_break\\"><span class=\\"ltx_text\\" style=\\"font-size:298%;\\">Huge</span> 
+<br class=\\"ltx_break\\"></p>
+</div>
+</section>
+<section id=\\"S4\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">4 </span>Colors</h2>
+
+<div id=\\"S4.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">black text <span class=\\"ltx_text\\" style=\\"color:#FF0000;\\">red text</span></p>
+</div>
+<div id=\\"S4.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\"><span class=\\"ltx_text\\" style=\\"color:#FFFFFF;background-color:#FF0000;\\">white text on red background</span></p>
+</div>
+</section>
+<section id=\\"S5\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">5 </span>Spacing</h2>
+
+<div id=\\"S5.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">The last two words have a non-breaking&nbsp;space.</p>
+</div>
+<div id=\\"S5.p2\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Before hfill.  After hfill.
+</p>
+</div>
+<span class=\\"ltx_ERROR undefined\\">{doublespace}</span>
+<div id=\\"S5.p3\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">This paragraph has 
+<br class=\\"ltx_break\\">double 
+<br class=\\"ltx_break\\">line spacing.</p>
+</div>
+</section>
+<section id=\\"S6\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">6 </span>Quotes</h2>
+
+<div id=\\"S6.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">To ‘quote’ in LaTeX 
+<br class=\\"ltx_break\\">To “quote” in LaTeX 
+<br class=\\"ltx_break\\">To “quote” in LaTeX 
+<br class=\\"ltx_break\\">To ,,quote” in LaTeX 
+<br class=\\"ltx_break\\">,,German quotation marks“ 
+<br class=\\"ltx_break\\">¡¡French quotation marks¿¿ 
+<br class=\\"ltx_break\\">“Please press the ‘x’ key.” 
+<br class=\\"ltx_break\\">,,ProszÄ, naciÅnij klawisz ¡¡x¿¿”.</p>
+</div>
+</section>
+<section id=\\"S7\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">7 </span>Super/subscript</h2>
+
+<div id=\\"S7.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Some<sup class=\\"ltx_sup\\">superscript</sup> 
+<br class=\\"ltx_break\\">Some<span class=\\"ltx_ERROR undefined\\">\\\\textsubscript</span>subscript</p>
+</div>
+</section>
+<section id=\\"S8\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">8 </span>Dashes and hypens</h2>
+
+<div id=\\"S8.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Hyphen: daughter-in-law, X-rated
+<br class=\\"ltx_break\\">En dash: pages 13–67
+<br class=\\"ltx_break\\">Em dash: yes—or no? 
+<br class=\\"ltx_break\\">Minus sign: <span id=\\"S8.p1.m1\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"0\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">0</span></span></span></span></span></span></span>, <span id=\\"S8.p1.m2\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"1\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span> and <span id=\\"S8.p1.m3\\" class=\\"ltx_Math\\"><span class=\\"mjpage\\"><span class=\\"mjx-chtml\\"><span class=\\"mjx-math\\" aria-label=\\"-1\\"><span class=\\"mjx-mrow\\" aria-hidden=\\"true\\"><span class=\\"mjx-mo\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.298em; padding-bottom: 0.446em;\\">−</span></span><span class=\\"mjx-mn\\"><span class=\\"mjx-char MJXc-TeX-main-R\\" style=\\"padding-top: 0.372em; padding-bottom: 0.372em;\\">1</span></span></span></span></span></span></span></p>
+</div>
+</section>
+<section id=\\"S9\\" class=\\"ltx_section\\">
+<h2 class=\\"ltx_title ltx_title_section\\">
+<span class=\\"ltx_tag ltx_tag_section\\">9 </span>Ellipsis</h2>
+
+<div id=\\"S9.p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\">Not like this … but like this:
+<br class=\\"ltx_break\\">New York, Tokyo, Budapest, …</p>
+</div>
+</section>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;
 
 exports[`urls.tex 1`] = `
-<div
-  class="ltx_page_main"
->
-  
-
-  <div
-    class="ltx_page_content"
-  >
-    
-
-    <article
-      class="ltx_document"
-    >
-      
-
-      <div
-        class="ltx_para"
-        id="p1"
-      >
-        
-
-        <p
-          class="ltx_p"
-        >
-          <span>
-            http link: 
-            <a
-              href="http://link.co.uk/to#something"
-            >
-              http://link.co.uk/to#something
-            </a>
-             
-
-          </span>
-          <br
-            class="ltx_break"
-          />
-          <span>
-            https link: 
-            <a
-              href="https://link.info?param"
-            >
-              https://link.info?param
-            </a>
-             url 
-
-          </span>
-          <br
-            class="ltx_break"
-          />
-          <span>
-            link with trailing period: 
-            <a
-              href="https://example.com."
-            >
-              https://example.com.
-            </a>
-             (FIXME: known failure) 
-
-          </span>
-          <br
-            class="ltx_break"
-          />
-          this should not make a link: foo.bar 
-
-          <br
-            class="ltx_break"
-          />
-          <span>
-            this is a link without leading space: badlatex.
-            <a
-              href="http://example.com"
-            >
-              http://example.com
-            </a>
-             
-
-          </span>
-          <br
-            class="ltx_break"
-          />
-          this is already a link with href: 
-          <a
-            class="ltx_ref ltx_href"
-            href="http://example.com"
-            title=""
-          >
-            example.com
-          </a>
-           
-
-          <br
-            class="ltx_break"
-          />
-          this is a link without http: 
-          <a
-            class="ltx_ref ltx_href"
-            href="http://example.com"
-            title=""
-          >
-            example.com
-          </a>
-           
-
-          <br
-            class="ltx_break"
-          />
-          this is already a link with url: 
-          <a
-            class="ltx_ref ltx_url ltx_font_typewriter"
-            href="http://example.com"
-            title=""
-          >
-            http://example.com
-          </a>
-           
-
-          <br
-            class="ltx_break"
-          />
-        </p>
-        
-
-      </div>
-      
-
-    </article>
-    
-
-  </div>
-  
-
-  <footer
-    class="ltx_page_footer"
-  >
-    
-
-    <div
-      class="ltx_page_logo"
-    >
-      Generated  by 
-      <a
-        href="http://dlmf.nist.gov/LaTeXML/"
-      >
-        LaTeXML 
-        <img
-          alt="[LOGO]"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg=="
-        />
-      </a>
-      
-
-    </div>
-  </footer>
-  
-
+"<div class=\\"ltx_page_main\\">
+<div class=\\"ltx_page_content\\">
+<article class=\\"ltx_document\\">
+<div id=\\"p1\\" class=\\"ltx_para\\">
+<p class=\\"ltx_p\\"><span>http link: <a href=\\"http://link.co.uk/to#something\\">http://link.co.uk/to#something</a> 
+</span><br class=\\"ltx_break\\"><span>https link: <a href=\\"https://link.info?param\\">https://link.info?param</a> url 
+</span><br class=\\"ltx_break\\"><span>link with trailing period: <a href=\\"https://example.com.\\">https://example.com.</a> (FIXME: known failure) 
+</span><br class=\\"ltx_break\\">this should not make a link: foo.bar 
+<br class=\\"ltx_break\\"><span>this is a link without leading space: badlatex.<a href=\\"http://example.com\\">http://example.com</a> 
+</span><br class=\\"ltx_break\\">this is already a link with href: <a href=\\"http://example.com\\" title=\\"\\" class=\\"ltx_ref ltx_href\\">example.com</a> 
+<br class=\\"ltx_break\\">this is a link without http: <a href=\\"http://example.com\\" title=\\"\\" class=\\"ltx_ref ltx_href\\">example.com</a> 
+<br class=\\"ltx_break\\">this is already a link with url: <a href=\\"http://example.com\\" title=\\"\\" class=\\"ltx_ref ltx_url ltx_font_typewriter\\">http://example.com</a> 
+<br class=\\"ltx_break\\"></p>
 </div>
+</article>
+</div>
+<footer class=\\"ltx_page_footer\\">
+<div class=\\"ltx_page_logo\\">Generated  by <a href=\\"http://dlmf.nist.gov/LaTeXML/\\">LaTeXML <img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==\\" alt=\\"[LOGO]\\"></a>
+</div></footer>
+</div>"
 `;

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -38,7 +38,7 @@ test.each(testDocuments())("%s", async (documentName, documentPath) => {
   // await fs.mkdirs(outputPath);
   const { htmlString, document } = await renderToDom(documentPath, outputPath);
 
-  expect(document.querySelector(".ltx_page_main")).toMatchSnapshot();
+  expect(document.querySelector(".ltx_page_main").outerHTML).toMatchSnapshot();
 
   percySnapshots.push({ documentName, htmlString });
 });


### PR DESCRIPTION
This fixes the weird spacing issues in some storybook stories.
Jest's DOM snapshotting adds meaningful space.