### PR TITLE
Use default mathjax font URL

### DIFF
--- a/src/converter/math.js
+++ b/src/converter/math.js
@@ -225,9 +225,6 @@ function renderMath(htmlString) {
 
   let pageConfig = {
     format: ["TeX"],
-    fontURL:
-      // TODO: get version from mathjax package
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/fonts/HTML-CSS",
     MathJax: mathjaxConfig
   };
 


### PR DESCRIPTION
Seems to be the same as default. Not sure why we redefined in the
first place.