### PR TITLE
Fix failing render for non-tarballed tex files.

### DIFF
--- a/src/converter/io.js
+++ b/src/converter/io.js
@@ -116,7 +116,7 @@ async function extractGzipToTmpdir(gzipPath) {
         console.log(
           "Input file is gzipped but not a tarball, assuming it is a .tex file"
         );
-        await fs.rename(gunzippedPath, path.join(tmpDir.path, "main.tex"));
+        await fs.move(gunzippedPath, path.join(tmpDir.path, "main.tex"));
       }
     } else {
       throw err;


### PR DESCRIPTION
Use `fs.move` instead of `fs.rename`. The operation is across filesystems mounted at different points (`/mnt/media/..` -> `/tmp`) and `fs.rename` does not work across different mount points.

This was giving me troubles when developing locally.