### PR TITLE
Deduplicate author footnotes.

### DIFF
--- a/src/assets/css/components/_ltx_authors.scss
+++ b/src/assets/css/components/_ltx_authors.scss
@@ -7,6 +7,12 @@
 
   .ltx_personname {
     font-weight: bold;
+
+    // In case of multiple notes per author, separate them with comma.
+    .ltx_note_mark:not(:last-child):after {
+      content: ",";
+    }
+
   }
 
   // No spaces between authors

--- a/src/converter/postprocessor/footnotes.js
+++ b/src/converter/postprocessor/footnotes.js
@@ -15,15 +15,26 @@ function authorFootnotes(document) {
     '<div class="ltx_engrafo_author_notes"></div>'
   );
   authors.appendChild(authorNotesContainer);
+  // In the laTeXML's output several authors can have the same note text
+  // and we want to deduplicate them. We'll use a dictionary to keep track of
+  // unique note texts.
+  const noteTextToMark = {};
   for (let note of notes) {
     const authorNote = nodeFromString(
       document,
       '<div class="ltx_note_outer"></div>'
     );
     const noteContent = note.querySelector(".ltx_note_content");
-    authorNote.appendChild(noteContent);
-    authorNotesContainer.appendChild(authorNote);
     const noteMark = note.querySelector(".ltx_note_mark");
+
+    const noteText = noteContent.lastChild.textContent;
+    if (!(noteText in noteTextToMark)) {
+      noteTextToMark[noteText] = Object.keys(noteTextToMark).length + 1;
+      authorNote.appendChild(noteContent);
+      authorNotesContainer.appendChild(authorNote);
+    }
+
+    noteMark.innerHTML = noteTextToMark[noteText];
     // Remove the footnote and replace with just the mark, because it isn't really a footnote any longer
     note.parentNode.replaceChild(noteMark, note);
   }

--- a/src/converter/postprocessor/footnotes.js
+++ b/src/converter/postprocessor/footnotes.js
@@ -20,10 +20,12 @@ function authorFootnotes(document) {
       document,
       '<div class="ltx_note_outer"></div>'
     );
-    authorNote.appendChild(note.querySelector(".ltx_note_content"));
+    const noteContent = note.querySelector(".ltx_note_content");
+    authorNote.appendChild(noteContent);
     authorNotesContainer.appendChild(authorNote);
+    const noteMark = note.querySelector(".ltx_note_mark");
     // Remove the footnote and replace with just the mark, because it isn't really a footnote any longer
-    note.parentNode.replaceChild(note.querySelector(".ltx_note_mark"), note);
+    note.parentNode.replaceChild(noteMark, note);
   }
 }
 

--- a/tests/integration-output/papers/1803.07574/main.tex/index.html
+++ b/tests/integration-output/papers/1803.07574/main.tex/index.html
@@ -144,15 +144,15 @@
 <span class="ltx_contact ltx_role_email"><a href="mailto:alina-georgiana.meresescu@u-psud.fr">alina-georgiana.meresescu@u-psud.fr</a>
 </span></span></span></span>
 <span class="ltx_creator ltx_role_author">
-<span class="ltx_personname">Matthieu Kowalski<sup class="ltx_note_mark">3</sup>
+<span class="ltx_personname">Matthieu Kowalski<sup class="ltx_note_mark">2</sup>
 </span></span>
 <span class="ltx_creator ltx_role_author">
-<span class="ltx_personname">Frédéric Schmidt<sup class="ltx_note_mark">4</sup>
+<span class="ltx_personname">Frédéric Schmidt<sup class="ltx_note_mark">1</sup>
 </span></span>
 <span class="ltx_creator ltx_role_author">
-<span class="ltx_personname">François Landais<sup class="ltx_note_mark">5</sup>
+<span class="ltx_personname">François Landais<sup class="ltx_note_mark">1</sup>
 </span></span>
-<div class="ltx_engrafo_author_notes"><div class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">1</sup><span class="ltx_tag ltx_tag_note">1</span>GEOPS, Univ. Paris-Sud, CNRS, Universite Paris-Saclay, Rue du Belvedere, Bat. 504-509, 91405 Orsay, France</span></div><div class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">2</sup><span class="ltx_tag ltx_tag_note">2</span>L2S, Univ. Paris-Sud, Supelec, CNRS, Universite Paris-Saclay, 3 rue Joliot Curie, 91192 Gif-sur-Yvette, France</span></div><div class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">3</sup><span class="ltx_tag ltx_tag_note">3</span>L2S, Univ. Paris-Sud, Supelec, CNRS, Universite Paris-Saclay, 3 rue Joliot Curie, 91192 Gif-sur-Yvette, France</span></div><div class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">4</sup><span class="ltx_tag ltx_tag_note">4</span>GEOPS, Univ. Paris-Sud, CNRS, Universite Paris-Saclay, Rue du Belvedere, Bat. 504-509, 91405 Orsay, France</span></div><div class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">5</sup><span class="ltx_tag ltx_tag_note">5</span>GEOPS, Univ. Paris-Sud, CNRS, Universite Paris-Saclay, Rue du Belvedere, Bat. 504-509, 91405 Orsay, France</span></div></div></div>
+<div class="ltx_engrafo_author_notes"><div class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">1</sup><span class="ltx_tag ltx_tag_note">1</span>GEOPS, Univ. Paris-Sud, CNRS, Universite Paris-Saclay, Rue du Belvedere, Bat. 504-509, 91405 Orsay, France</span></div><div class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">2</sup><span class="ltx_tag ltx_tag_note">2</span>L2S, Univ. Paris-Sud, Supelec, CNRS, Universite Paris-Saclay, 3 rue Joliot Curie, 91192 Gif-sur-Yvette, France</span></div></div></div>
 
 <div class="ltx_abstract">
 <h6 class="ltx_title ltx_title_abstract">Abstract</h6>


### PR DESCRIPTION
This is my proposal for a fix that resolves https://github.com/arxiv-vanity/engrafo/issues/518. 

Additionally, in 30818dd I'm proposing to separate author footnotes with a comma, to also be consistent with pdfs. Wdyt?

This is how the paper in question (https://www.arxiv-vanity.com/papers/1803.07574/) would look like after my patch:

<img width="746" alt="Screenshot 2019-05-28 at 21 57 02" src="https://user-images.githubusercontent.com/7057316/58508373-31abdb00-8194-11e9-968a-2cc3bd6f8eb3.png">
