### PR TITLE
Add scroll to long algorithm lines (...)

### DIFF
--- a/src/assets/css/components/_ltx_listing.scss
+++ b/src/assets/css/components/_ltx_listing.scss
@@ -6,11 +6,9 @@
   padding-left: 3em;
   margin: 4rem 0;
 
-  @include media("<desktop") {
-    max-width: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
-  }
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
 
   // Remove download button. It's much easier to copy and paste
   .ltx_listing_data {


### PR DESCRIPTION
Should fix issue #505 in all viewports.
Alternative is to remove { white-space: nowrap } on .ltx_listingline,
but decided that keeping the same functionality across mobile + desktop
experience would be better.