### PR TITLE
make script/docker-build executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ FROM debian:testing-20200720
 # Change logs here: https://packages.debian.org/buster/texlive-full
 RUN apt-get update -qq && apt-get install -qy texlive-full
 
+RUN apt-get install python2-minimal equivs -qy
+ADD dummy-python-minimal.equivs .
+RUN equivs-build dummy-python-minimal.equivs \
+    && dpkg -i python-minimal_99_all.deb
+
 RUN set -ex \
     && apt-get update -qq \
     && apt-get install -qy \
@@ -14,7 +19,6 @@ RUN set -ex \
     # Node.js dependencies \
     ca-certificates \
     git-core \
-    python-minimal \
     # latexml dependencies \
     libarchive-zip-perl libfile-which-perl libimage-size-perl  \
     libio-string-perl libjson-xs-perl libtext-unidecode-perl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:testing-20200720
 # Change logs here: https://packages.debian.org/buster/texlive-full
 RUN apt-get update -qq && apt-get install -qy texlive-full
 
-RUN apt-get install python2-minimal equivs -qy
+RUN apt-get update -qy && apt-get install python2-minimal equivs -qy
 ADD dummy-python-minimal.equivs .
 RUN equivs-build dummy-python-minimal.equivs \
     && dpkg -i python-minimal_99_all.deb

--- a/dummy-python-minimal.equivs
+++ b/dummy-python-minimal.equivs
@@ -1,0 +1,6 @@
+Package: python-minimal
+Version: 99:99
+Maintainer: Your Name <you@example.com>
+Architecture: all
+Description: dummy python-minimal package
+ A dummy package providing python-minimal for nodesource nodejs repository.


### PR DESCRIPTION
https://github.com/arxiv-vanity/engrafo/issues/1079
The following is a reference.
https://github.com/nodesource/distributions/issues/1100#issuecomment-692586611

`nodejs` depends on `python-minimal`, but currently it is not possible to install this package on debian apt-get.
Instead, the problem is avoided by installing `python2-minimal` and creating a dummy package with `equivs`.